### PR TITLE
Feature/clothing crud - POST, GET API 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,14 @@ repositories {
     mavenCentral()
 }
 
+sourceSets {
+    main {
+        java {
+            srcDirs += "$buildDir/generated/sources/annotationProcessor/java/main"
+        }
+    }
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -36,7 +44,15 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Valid 어노테이션
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/team3/otboo/config/QuerydslConfig.java
+++ b/src/main/java/com/team3/otboo/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.team3.otboo.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/team3/otboo/domain/clothing/controller/ClothingAttributeDefController.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/controller/ClothingAttributeDefController.java
@@ -2,14 +2,18 @@ package com.team3.otboo.domain.clothing.controller;
 
 import com.team3.otboo.domain.clothing.dto.ClothingAttributeDefDto;
 import com.team3.otboo.domain.clothing.dto.request.ClothingAttributeDefCreateRequest;
+import com.team3.otboo.domain.clothing.dto.response.CursorPageResponse;
 import com.team3.otboo.domain.clothing.service.ClothingAttributeDefService;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -24,5 +28,23 @@ public class ClothingAttributeDefController {
             @RequestBody @Valid ClothingAttributeDefCreateRequest request) {
         ClothingAttributeDefDto dto = service.create(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(dto);
+    }
+
+    @GetMapping
+    public ResponseEntity<CursorPageResponse<ClothingAttributeDefDto>> getAttributes(
+            @RequestParam(required = false) String cursor,
+            @RequestParam(required = false) UUID idAfter,
+            @RequestParam int limit,
+            @RequestParam(required = false) String sortBy,
+            @RequestParam(required = false, defaultValue = "DESCENDING") String sortDirection,
+            @RequestParam(required = false) String keywordLike
+    ) {
+        // 커서가 없는 경우 idAfter로 대체
+        String effectiveCursor = (cursor != null) ? cursor :
+                (idAfter != null) ? idAfter.toString() : null;
+
+        return ResponseEntity.ok(
+                service.getAttributes(effectiveCursor, limit, sortBy, sortDirection, keywordLike)
+        );
     }
 }

--- a/src/main/java/com/team3/otboo/domain/clothing/controller/ClothingAttributeDefController.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/controller/ClothingAttributeDefController.java
@@ -1,0 +1,28 @@
+package com.team3.otboo.domain.clothing.controller;
+
+import com.team3.otboo.domain.clothing.dto.ClothingAttributeDefDto;
+import com.team3.otboo.domain.clothing.dto.request.ClothingAttributeDefCreateRequest;
+import com.team3.otboo.domain.clothing.service.ClothingAttributeDefService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/clothes/attribute-defs")
+public class ClothingAttributeDefController {
+
+    private final ClothingAttributeDefService service;
+
+    @PostMapping
+    public ResponseEntity<ClothingAttributeDefDto> create(
+            @RequestBody @Valid ClothingAttributeDefCreateRequest request) {
+        ClothingAttributeDefDto dto = service.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(dto);
+    }
+}

--- a/src/main/java/com/team3/otboo/domain/clothing/dto/response/CursorPageResponse.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/dto/response/CursorPageResponse.java
@@ -1,0 +1,11 @@
+package com.team3.otboo.domain.clothing.dto.response;
+
+import java.util.List;
+
+public record CursorPageResponse<T>(
+        List<T> data,
+        String nextCursor,
+        String sortBy,
+        String sortDirection,
+        Long totalCount
+) {}

--- a/src/main/java/com/team3/otboo/domain/clothing/entity/Attribute.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/entity/Attribute.java
@@ -6,11 +6,38 @@ import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
 import jakarta.persistence.CascadeType;
+import java.util.UUID;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class Attribute extends BaseEntity {
     private String name; // 예: 스타일, 컬러, 촉감 등
 
     @OneToMany(mappedBy = "attribute", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<AttributeOption> options = new ArrayList<>();
+
+    public static Attribute of(String name, List<String> values) {
+        Attribute attribute = new Attribute();
+        attribute.name = name;
+
+        values.forEach(attribute::addOption);
+        return attribute;
+    }
+
+    public void addOption(String value) {
+        AttributeOption option = AttributeOption.of(value, this);
+        this.options.add(option);
+    }
+
+    public void removeOption(UUID optionId) {
+        this.options.removeIf(option -> option.getId().equals(optionId));
+    }
+
+    public void updateOptionValue(UUID optionId, String newValue) {
+        this.options.stream()
+                .filter(option -> option.getId().equals(optionId))
+                .findFirst()
+                .ifPresent(option -> option.updateValue(newValue));
+    }
 }

--- a/src/main/java/com/team3/otboo/domain/clothing/entity/Attribute.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/entity/Attribute.java
@@ -7,10 +7,13 @@ import java.util.ArrayList;
 import java.util.List;
 import jakarta.persistence.CascadeType;
 import java.util.UUID;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Attribute extends BaseEntity {
     private String name; // 예: 스타일, 컬러, 촉감 등
 

--- a/src/main/java/com/team3/otboo/domain/clothing/entity/AttributeOption.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/entity/AttributeOption.java
@@ -4,10 +4,13 @@ import com.team3.otboo.domain.base.entity.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AttributeOption extends BaseEntity {
 
     private String value; // 예: 블랙, S, 캐주얼

--- a/src/main/java/com/team3/otboo/domain/clothing/entity/AttributeOption.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/entity/AttributeOption.java
@@ -4,12 +4,30 @@ import com.team3.otboo.domain.base.entity.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ManyToOne;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class AttributeOption extends BaseEntity {
 
     private String value; // 예: 블랙, S, 캐주얼
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Attribute attribute;
+
+    // 연관관계 설정
+    public void assignAttribute(Attribute attribute) {
+        this.attribute = attribute;
+    }
+
+    public static AttributeOption of(String value, Attribute attribute) {
+        AttributeOption option = new AttributeOption();
+        option.value = value;
+        option.assignAttribute(attribute);
+        return option;
+    }
+
+    public void updateValue(String newValue) {
+        this.value = newValue;
+    }
 }

--- a/src/main/java/com/team3/otboo/domain/clothing/entity/Clothing.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/entity/Clothing.java
@@ -9,8 +9,11 @@ import java.util.ArrayList;
 import java.util.List;
 import jakarta.persistence.CascadeType;
 import com.team3.otboo.domain.user.entity.User;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Clothing extends BaseEntity {
 
     private String name; // 의상 이름

--- a/src/main/java/com/team3/otboo/domain/clothing/entity/ClothingAttributeValue.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/entity/ClothingAttributeValue.java
@@ -4,8 +4,11 @@ import com.team3.otboo.domain.base.entity.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ClothingAttributeValue extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/team3/otboo/domain/clothing/mapper/ClothingAttributeDefMapper.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/mapper/ClothingAttributeDefMapper.java
@@ -1,0 +1,28 @@
+package com.team3.otboo.domain.clothing.mapper;
+
+import com.team3.otboo.domain.clothing.dto.ClothingAttributeDefDto;
+import com.team3.otboo.domain.clothing.dto.request.ClothingAttributeDefCreateRequest;
+import com.team3.otboo.domain.clothing.entity.Attribute;
+import com.team3.otboo.domain.clothing.entity.AttributeOption;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ClothingAttributeDefMapper {
+
+    public Attribute toEntity(ClothingAttributeDefCreateRequest request) {
+        return Attribute.of(request.name(), request.selectableValues());
+    }
+
+    public ClothingAttributeDefDto toDto(Attribute attribute) {
+        List<String> values = attribute.getOptions().stream()
+                .map(AttributeOption::getValue)
+                .toList();
+
+        return new ClothingAttributeDefDto(
+                attribute.getId(),
+                attribute.getName(),
+                values
+        );
+    }
+}

--- a/src/main/java/com/team3/otboo/domain/clothing/mapper/ClothingAttributeDefMapper.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/mapper/ClothingAttributeDefMapper.java
@@ -25,4 +25,8 @@ public class ClothingAttributeDefMapper {
                 values
         );
     }
+
+    public List<ClothingAttributeDefDto> toDtoList(List<Attribute> attributes) {
+        return attributes.stream().map(this::toDto).toList();
+    }
 }

--- a/src/main/java/com/team3/otboo/domain/clothing/repository/AttributeOptionRepository.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/repository/AttributeOptionRepository.java
@@ -1,0 +1,7 @@
+package com.team3.otboo.domain.clothing.repository;
+
+import com.team3.otboo.domain.clothing.entity.AttributeOption;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AttributeOptionRepository extends JpaRepository<AttributeOption, UUID> {}

--- a/src/main/java/com/team3/otboo/domain/clothing/repository/AttributeRepository.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/repository/AttributeRepository.java
@@ -4,4 +4,4 @@ import com.team3.otboo.domain.clothing.entity.Attribute;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AttributeRepository extends JpaRepository<Attribute, UUID> {}
+public interface AttributeRepository extends JpaRepository<Attribute, UUID>, AttributeRepositoryCustom {}

--- a/src/main/java/com/team3/otboo/domain/clothing/repository/AttributeRepository.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/repository/AttributeRepository.java
@@ -1,0 +1,7 @@
+package com.team3.otboo.domain.clothing.repository;
+
+import com.team3.otboo.domain.clothing.entity.Attribute;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AttributeRepository extends JpaRepository<Attribute, UUID> {}

--- a/src/main/java/com/team3/otboo/domain/clothing/repository/AttributeRepositoryCustom.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/repository/AttributeRepositoryCustom.java
@@ -1,0 +1,15 @@
+package com.team3.otboo.domain.clothing.repository;
+
+import com.team3.otboo.domain.clothing.dto.response.CursorPageResponse;
+import com.team3.otboo.domain.clothing.entity.Attribute;
+import org.springframework.data.domain.Sort;
+
+public interface AttributeRepositoryCustom {
+    CursorPageResponse<Attribute> findAllByCursor(
+            String cursor,
+            int limit,
+            String sortBy,
+            Sort.Direction direction,
+            String keyword
+    );
+}

--- a/src/main/java/com/team3/otboo/domain/clothing/repository/AttributeRepositoryImpl.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/repository/AttributeRepositoryImpl.java
@@ -1,0 +1,83 @@
+package com.team3.otboo.domain.clothing.repository;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.team3.otboo.domain.clothing.dto.response.CursorPageResponse;
+import com.team3.otboo.domain.clothing.entity.QAttribute;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+import com.team3.otboo.domain.clothing.entity.Attribute;
+
+
+
+@Repository
+@RequiredArgsConstructor
+public class AttributeRepositoryImpl implements AttributeRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public CursorPageResponse<Attribute> findAllByCursor(
+            String cursor,
+            int limit,
+            String sortBy,
+            Sort.Direction direction,
+            String keyword
+    ) {
+        // QueryDSL 시작
+        QAttribute attribute = QAttribute.attribute;
+
+        List<Attribute> results = queryFactory
+                .selectFrom(attribute)
+                .where( // null 조건은 자동 제외
+                        cursorCondition(attribute, cursor, direction), // 커서
+                        keyword != null ? attribute.name.containsIgnoreCase(keyword) : null // 키워드
+                )
+                .orderBy(getSortOrder(attribute, sortBy, direction))
+                .limit(limit + 1)
+                .fetch();
+
+        boolean hasNext = results.size() > limit;
+        List<Attribute> content = hasNext ? results.subList(0, limit) : results;
+        String nextCursor = hasNext ? content.get(content.size() - 1).getId().toString() : null;
+
+        Long totalCount = queryFactory
+                .select(attribute.count())
+                .from(attribute)
+                .fetchOne();
+
+        return new CursorPageResponse<>(
+                content,
+                nextCursor,
+                sortBy,
+                direction.name(),
+                totalCount
+        );
+    }
+
+    private BooleanExpression cursorCondition(QAttribute attribute, String cursor, Sort.Direction direction) {
+        if (cursor == null) return null;
+        UUID cursorId = UUID.fromString(cursor);
+        // 정렬 방향에 따른 조회 조건 생성
+        return direction.isAscending()
+                ? attribute.id.gt(cursorId)
+                : attribute.id.lt(cursorId);
+    }
+
+    private OrderSpecifier<?> getSortOrder(QAttribute attribute, String sortBy, Sort.Direction direction) {
+//        PathBuilder<Attribute> entityPath = new PathBuilder<>(Attribute.class, "attribute");
+
+        if (sortBy == null || sortBy.equals("createdAt")) {
+            return direction.isAscending() ? attribute.createdAt.asc() : attribute.createdAt.desc();
+        } else if (sortBy.equals("name")) {
+            return direction.isAscending() ? attribute.name.asc() : attribute.name.desc();
+        } else {
+            return direction.isAscending() ? attribute.id.asc() : attribute.id.desc();
+        }
+    }
+}

--- a/src/main/java/com/team3/otboo/domain/clothing/service/ClothingAttributeDefService.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/service/ClothingAttributeDefService.java
@@ -1,0 +1,8 @@
+package com.team3.otboo.domain.clothing.service;
+
+import com.team3.otboo.domain.clothing.dto.ClothingAttributeDefDto;
+import com.team3.otboo.domain.clothing.dto.request.ClothingAttributeDefCreateRequest;
+
+public interface ClothingAttributeDefService {
+    ClothingAttributeDefDto create(ClothingAttributeDefCreateRequest request);
+}

--- a/src/main/java/com/team3/otboo/domain/clothing/service/ClothingAttributeDefService.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/service/ClothingAttributeDefService.java
@@ -2,7 +2,17 @@ package com.team3.otboo.domain.clothing.service;
 
 import com.team3.otboo.domain.clothing.dto.ClothingAttributeDefDto;
 import com.team3.otboo.domain.clothing.dto.request.ClothingAttributeDefCreateRequest;
+import com.team3.otboo.domain.clothing.dto.response.CursorPageResponse;
+
 
 public interface ClothingAttributeDefService {
     ClothingAttributeDefDto create(ClothingAttributeDefCreateRequest request);
+
+    CursorPageResponse<ClothingAttributeDefDto> getAttributes(
+            String cursor,
+            int limit,
+            String sortBy,
+            String sortDirection,
+            String keyword
+    );
 }

--- a/src/main/java/com/team3/otboo/domain/clothing/service/ClothingAttributeDefServiceImpl.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/service/ClothingAttributeDefServiceImpl.java
@@ -2,10 +2,13 @@ package com.team3.otboo.domain.clothing.service;
 
 import com.team3.otboo.domain.clothing.dto.ClothingAttributeDefDto;
 import com.team3.otboo.domain.clothing.dto.request.ClothingAttributeDefCreateRequest;
+import com.team3.otboo.domain.clothing.dto.response.CursorPageResponse;
 import com.team3.otboo.domain.clothing.entity.Attribute;
 import com.team3.otboo.domain.clothing.mapper.ClothingAttributeDefMapper;
 import com.team3.otboo.domain.clothing.repository.AttributeRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -20,5 +23,28 @@ public class ClothingAttributeDefServiceImpl implements ClothingAttributeDefServ
         Attribute attribute = mapper.toEntity(request);
         Attribute saved = attributeRepository.save(attribute);
         return mapper.toDto(saved);
+    }
+
+    @Override
+    public CursorPageResponse<ClothingAttributeDefDto> getAttributes(
+            String cursor,
+            int limit,
+            String sortBy,
+            String sortDirection,
+            String keyword
+    ) {
+        Sort.Direction direction = Sort.Direction.fromOptionalString(sortDirection).orElse(Sort.Direction.DESC);
+        CursorPageResponse<Attribute> result = attributeRepository.findAllByCursor(cursor, limit, sortBy, direction, keyword);
+        List<ClothingAttributeDefDto> dtoList = result.data().stream()
+                .map(mapper::toDto)
+                .toList();
+
+        return new CursorPageResponse<>(
+                dtoList,
+                result.nextCursor(),
+                result.sortBy(),
+                result.sortDirection(),
+                result.totalCount()
+        );
     }
 }

--- a/src/main/java/com/team3/otboo/domain/clothing/service/ClothingAttributeDefServiceImpl.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/service/ClothingAttributeDefServiceImpl.java
@@ -1,0 +1,24 @@
+package com.team3.otboo.domain.clothing.service;
+
+import com.team3.otboo.domain.clothing.dto.ClothingAttributeDefDto;
+import com.team3.otboo.domain.clothing.dto.request.ClothingAttributeDefCreateRequest;
+import com.team3.otboo.domain.clothing.entity.Attribute;
+import com.team3.otboo.domain.clothing.mapper.ClothingAttributeDefMapper;
+import com.team3.otboo.domain.clothing.repository.AttributeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ClothingAttributeDefServiceImpl implements ClothingAttributeDefService {
+
+    private final AttributeRepository attributeRepository;
+    private final ClothingAttributeDefMapper mapper;
+
+    @Override
+    public ClothingAttributeDefDto create(ClothingAttributeDefCreateRequest request) {
+        Attribute attribute = mapper.toEntity(request);
+        Attribute saved = attributeRepository.save(attribute);
+        return mapper.toDto(saved);
+    }
+}

--- a/src/main/java/com/team3/otboo/domain/dm/dto/DirectMessageDto.java
+++ b/src/main/java/com/team3/otboo/domain/dm/dto/DirectMessageDto.java
@@ -1,5 +1,6 @@
 package com.team3.otboo.domain.dm.dto;
 
+import com.team3.otboo.domain.user.dto.UserSummary;
 import java.time.LocalDateTime;
 import java.util.UUID;
 

--- a/src/main/java/com/team3/otboo/domain/feed/dto/FeedDto.java
+++ b/src/main/java/com/team3/otboo/domain/feed/dto/FeedDto.java
@@ -3,6 +3,7 @@ package com.team3.otboo.domain.feed.dto;
 
 import com.team3.otboo.domain.weather.dto.WeatherDto;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 public record FeedDto(
@@ -11,7 +12,7 @@ public record FeedDto(
 	LocalDateTime updatedAt,
 	AuthorDto author,
 	WeatherDto weather,
-	List<OotodDto> ootds,
+	List<OotdDto> ootds,
 	String content,
 	Long likeCount,
 	Integer CommentCount,

--- a/src/main/java/com/team3/otboo/domain/feed/dto/OotdDto.java
+++ b/src/main/java/com/team3/otboo/domain/feed/dto/OotdDto.java
@@ -1,5 +1,7 @@
 package com.team3.otboo.domain.feed.dto;
 
+import com.team3.otboo.domain.clothing.dto.ClothingAttributeWithDefDto;
+import java.util.List;
 import java.util.UUID;
 import lombok.Data;
 
@@ -8,7 +10,7 @@ public record OotdDto(
 	String name,
 	String imageUrl,
 	String type,
-	List<ClothesAttributeWithDefDto> attributes
+	List<ClothingAttributeWithDefDto> attributes
 ) {
 
 }


### PR DESCRIPTION
## 구현내용

의상에 대한 CRUD API 구현 전, 의상에 적용되는 속성에 대한 CRUD API를 먼저 구현하고 있습니다.
현재 Create, Read 구현한 상태이고 작업 내용이 길어져 우선 PR 등록하였습니다.

- 의상 속성 정의
의상 속성 정의 목록 등록을 위한 `POST /api/clothes/attribute-defs` API 구현
의상 속성 정의 등록을 위한 `GET /api/clothes/attribute-defs` API 구현.

- build.gradle
유연한 처리를 위한 QueryDSL 적용
@Valid 사용을 위한 설정 추가

- FeedDto, OotdDto, DirectMessageDto 오탈자 및 import 수정

---
## 관련 문서
[의상 속성 정의 목록 등록 API](https://www.notion.so/POST-api-clothes-attribute-defs-23fe5eb32ae08058b786c506e8428571?source=copy_link)
[의상 속성 정의 목록 조회 API](https://www.notion.so/GET-api-clothes-attribute-defs-API-23fe5eb32ae0809b85c7d6e232a87df0?source=copy_link)
[QueryDSL](https://www.notion.so/QueryDSL-23fe5eb32ae080db8519cc4d4978f756?source=copy_link)

---

## 관련 이슈
#55 