### PR TITLE
Feature/clothing crud - DELETE, PATCH API 구현

### DIFF
--- a/src/main/java/com/team3/otboo/domain/clothing/controller/ClothingAttributeDefController.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/controller/ClothingAttributeDefController.java
@@ -12,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -26,7 +27,6 @@ public class ClothingAttributeDefController {
 
     private final ClothingAttributeDefService service;
 
-//    추후 권한 등록 완료 시 적용
     @PreAuthorize("hasRole('ADMIN')")
     @PostMapping
     public ResponseEntity<ClothingAttributeDefDto> create(
@@ -58,6 +58,16 @@ public class ClothingAttributeDefController {
     public ResponseEntity<Void> deleteAttributeDefinition(@PathVariable UUID definitionId) {
         service.deleteAttribute(definitionId);
         return ResponseEntity.noContent().build();
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PatchMapping("/{definitionId}")
+    public ResponseEntity<ClothingAttributeDefDto> updateAttributeDef(
+            @PathVariable UUID definitionId,
+            @RequestBody ClothingAttributeDefCreateRequest request) {
+
+        ClothingAttributeDefDto response = service.updateAttribute(definitionId, request);
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/src/main/java/com/team3/otboo/domain/clothing/controller/ClothingAttributeDefController.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/controller/ClothingAttributeDefController.java
@@ -9,7 +9,10 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,6 +26,8 @@ public class ClothingAttributeDefController {
 
     private final ClothingAttributeDefService service;
 
+//    추후 권한 등록 완료 시 적용
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping
     public ResponseEntity<ClothingAttributeDefDto> create(
             @RequestBody @Valid ClothingAttributeDefCreateRequest request) {
@@ -47,4 +52,12 @@ public class ClothingAttributeDefController {
                 service.getAttributes(effectiveCursor, limit, sortBy, sortDirection, keywordLike)
         );
     }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/{definitionId}")
+    public ResponseEntity<Void> deleteAttributeDefinition(@PathVariable UUID definitionId) {
+        service.deleteAttribute(definitionId);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/com/team3/otboo/domain/clothing/entity/Attribute.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/entity/Attribute.java
@@ -33,14 +33,12 @@ public class Attribute extends BaseEntity {
         this.options.add(option);
     }
 
-    public void removeOption(UUID optionId) {
-        this.options.removeIf(option -> option.getId().equals(optionId));
+    public void updateName(String newName) {
+        this.name = newName;
     }
 
-    public void updateOptionValue(UUID optionId, String newValue) {
-        this.options.stream()
-                .filter(option -> option.getId().equals(optionId))
-                .findFirst()
-                .ifPresent(option -> option.updateValue(newValue));
+    public void replaceOptions(List<String> newValues) {
+        this.options.clear(); // 기존 옵션 모두 제거됨 (orphanRemoval)
+        newValues.forEach(this::addOption);
     }
 }

--- a/src/main/java/com/team3/otboo/domain/clothing/service/ClothingAttributeDefService.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/service/ClothingAttributeDefService.java
@@ -3,6 +3,7 @@ package com.team3.otboo.domain.clothing.service;
 import com.team3.otboo.domain.clothing.dto.ClothingAttributeDefDto;
 import com.team3.otboo.domain.clothing.dto.request.ClothingAttributeDefCreateRequest;
 import com.team3.otboo.domain.clothing.dto.response.CursorPageResponse;
+import java.util.UUID;
 
 
 public interface ClothingAttributeDefService {
@@ -15,4 +16,6 @@ public interface ClothingAttributeDefService {
             String sortDirection,
             String keyword
     );
+
+    void deleteAttribute(UUID definitionId);
 }

--- a/src/main/java/com/team3/otboo/domain/clothing/service/ClothingAttributeDefService.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/service/ClothingAttributeDefService.java
@@ -18,4 +18,6 @@ public interface ClothingAttributeDefService {
     );
 
     void deleteAttribute(UUID definitionId);
+
+    ClothingAttributeDefDto updateAttribute(UUID definitionId, ClothingAttributeDefCreateRequest request);
 }

--- a/src/main/java/com/team3/otboo/domain/clothing/service/ClothingAttributeDefServiceImpl.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/service/ClothingAttributeDefServiceImpl.java
@@ -6,7 +6,10 @@ import com.team3.otboo.domain.clothing.dto.response.CursorPageResponse;
 import com.team3.otboo.domain.clothing.entity.Attribute;
 import com.team3.otboo.domain.clothing.mapper.ClothingAttributeDefMapper;
 import com.team3.otboo.domain.clothing.repository.AttributeRepository;
+import jakarta.transaction.Transactional;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
@@ -47,4 +50,14 @@ public class ClothingAttributeDefServiceImpl implements ClothingAttributeDefServ
                 result.totalCount()
         );
     }
+
+    @Transactional
+    @Override
+    public void deleteAttribute(UUID definitionId) {
+        Attribute attribute = attributeRepository.findById(definitionId)
+                .orElseThrow(() -> new NoSuchElementException("해당 속성을 찾을 수 없습니다."));
+
+        attributeRepository.delete(attribute);
+    }
+
 }

--- a/src/main/java/com/team3/otboo/domain/clothing/service/ClothingAttributeDefServiceImpl.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/service/ClothingAttributeDefServiceImpl.java
@@ -22,6 +22,7 @@ public class ClothingAttributeDefServiceImpl implements ClothingAttributeDefServ
     private final ClothingAttributeDefMapper mapper;
 
     @Override
+    @Transactional
     public ClothingAttributeDefDto create(ClothingAttributeDefCreateRequest request) {
         Attribute attribute = mapper.toEntity(request);
         Attribute saved = attributeRepository.save(attribute);
@@ -51,8 +52,8 @@ public class ClothingAttributeDefServiceImpl implements ClothingAttributeDefServ
         );
     }
 
-    @Transactional
     @Override
+    @Transactional
     public void deleteAttribute(UUID definitionId) {
         Attribute attribute = attributeRepository.findById(definitionId)
                 .orElseThrow(() -> new NoSuchElementException("해당 속성을 찾을 수 없습니다."));
@@ -60,4 +61,17 @@ public class ClothingAttributeDefServiceImpl implements ClothingAttributeDefServ
         attributeRepository.delete(attribute);
     }
 
+    @Override
+    @Transactional
+    public ClothingAttributeDefDto updateAttribute(UUID definitionId,
+            ClothingAttributeDefCreateRequest request) {
+        Attribute attribute = attributeRepository.findById(definitionId)
+                .orElseThrow(() -> new NoSuchElementException("해당 속성을 찾을 수 없습니다."));
+
+        // 이름 변경
+        attribute.updateName(request.name());
+        attribute.replaceOptions(request.selectableValues());
+
+        return mapper.toDto(attribute);
+    }
 }


### PR DESCRIPTION
## 구현내용

- 의상 속성 정의
의상 속성 정의 목록 삭제를 위한 `DELETE /api/clothes/attribute-defs/{definitionId}` API 구현
의상 속성 정의 수정을 위한 `PATCH /api/clothes/attribute-defs/{definitnionId}` API 구현.

예외 처리와 관련된 부분은 추후 공통 전역 핸들러가 추가되면 수정하겠습니다.(현재 임시 구현)
의상 속성 수정을 "ADMIN" 권한을 가진 사용자만 변경할 수 있도록 설정했는데, 이 부분은 추후 User 엔티티 구현에 따라 변경할 수 있습니다.

---
## 관련 문서
[의상 속성 정의 목록 삭제 API](https://www.notion.so/DELETE-api-clothes-attribute-defs-definitionId-23fe5eb32ae080da9081f04d1478e184?source=copy_link)
[의상 속성 정의 수정 API](https://www.notion.so/PATCH-api-clothes-attribute-defs-definitionId-23fe5eb32ae080d9bb89eb518a744147?source=copy_link)


---

## 관련 이슈
#55 