### PR TITLE
중복 팔로우 방지 대책 및 count 쿼리로 인한 성능 저하 문제 해결

### DIFF
--- a/src/main/java/com/team3/otboo/domain/feed/entity/Feed.java
+++ b/src/main/java/com/team3/otboo/domain/feed/entity/Feed.java
@@ -3,18 +3,12 @@ package com.team3.otboo.domain.feed.entity;
 import com.team3.otboo.domain.base.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 
 @Table
 @Entity
@@ -32,11 +26,12 @@ public class Feed extends BaseEntity {
 	@Column(nullable = false, columnDefinition = "TEXT")
 	private String content;
 
-	@Column(nullable = false)
-	private int likeCount;
-
-	@Column(nullable = false)
-	private int commentCount;
+	// 엔티티 카운트 필드에 메모리에서 증가시키는 방식을 말고, 데이터 베이스 수준 lock 을 사용해야함 .
+//	@Column(nullable = false)
+//	private int likeCount;
+//
+//	@Column(nullable = false)
+//	private int commentCount;
 
 	public static Feed create(UUID authorId, UUID weatherId, String content) {
 		Feed feed = new Feed();

--- a/src/main/java/com/team3/otboo/domain/follow/entity/Follow.java
+++ b/src/main/java/com/team3/otboo/domain/follow/entity/Follow.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -13,9 +14,15 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 
-@Table(name = "follows")
+@Table(
+	name = "follows",
+	uniqueConstraints = {
+		@UniqueConstraint(
+			columnNames = {"followeeId", "followerId"}
+		)
+	}
+)
 @Entity
 @Getter
 @ToString
@@ -29,13 +36,13 @@ public class Follow {
 	@CreatedDate
 	private LocalDateTime createdAt;
 
-	@Column(nullable =false)
+	@Column(nullable = false)
 	private UUID followeeId;
 
 	@Column(nullable = false)
 	private UUID followerId;
 
-	public static Follow create(UUID followeeId, UUID followerId){
+	public static Follow create(UUID followeeId, UUID followerId) {
 		Follow follow = new Follow();
 		follow.followeeId = followeeId;
 		follow.followerId = followerId;

--- a/src/main/java/com/team3/otboo/domain/follow/repository/UserFollowerCountRepository.java
+++ b/src/main/java/com/team3/otboo/domain/follow/repository/UserFollowerCountRepository.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UserFollowerCountRepository extends JpaRepository<UserFollowerCount, UUID> {
 
+	// 대규모 트래픽이 예상되는 상황에서 팔로워, 팔로잉 수를 세는데 count 쿼리를 사용하면 너무 오래결럼 UserFollowerCount, UserFollowingCount 라는 객체를 따로 저장
 	@Query(
 		value = "update user_follower_count set follower_count = follower_count + 1 where userId = :userId",
 		nativeQuery = true


### PR DESCRIPTION
## 중복 팔로우 방지 대책

follow 테이블에 followerId, followeeId 유니크 제약 추가로 데이터베이스 레벨에서 중복 팔로우 방지

## count 쿼리의 성능 문제
대규모 트래픽이 예상 되는 서비스에서 count 쿼리로 팔로워, 팔로잉을 세는데 성능 문제가 있었습니다.
(1200만건의 팔로우를 count 하는데 걸리는 시간 -> 약 1.2초)

follower/following 카운트 테이블을 별도로 생성하고, 팔로우/언팔로우 시 카운트 값을 미리 갱신하는 구조로 변경하여 count 쿼리 성능 이슈를 해결하였습니다.

