### PR TITLE
feat: 전역 예외 핸들러 구현

### DIFF
--- a/src/main/java/com/team3/otboo/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/team3/otboo/domain/recommendation/service/RecommendationService.java
@@ -10,6 +10,7 @@ import com.team3.otboo.domain.user.repository.UserRepository;
 import com.team3.otboo.domain.user.service.ProfileService;
 import com.team3.otboo.domain.weather.dto.WeatherDto;
 import com.team3.otboo.domain.weather.service.WeatherService;
+import com.team3.otboo.global.exception.user.UserNotFoundException;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +28,7 @@ public class RecommendationService {
 
   public RecommendationDto recommend(UUID userId) {
     User user = userRepository.findById(userId)
-        .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        .orElseThrow(UserNotFoundException::new);
 
     ProfileDto profile = profileService.getProfile(userId);
     List<Clothing> clothes = clothesService.getClothesByOwner(user);

--- a/src/main/java/com/team3/otboo/global/exception/BusinessException.java
+++ b/src/main/java/com/team3/otboo/global/exception/BusinessException.java
@@ -1,0 +1,21 @@
+package com.team3.otboo.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+  private final ErrorCode errorCode;
+  private final String detailMessage;
+
+  public BusinessException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+    this.detailMessage = errorCode.getMessage();
+  }
+
+  public BusinessException(ErrorCode errorCode, String detailMessage) {
+    super(detailMessage);
+    this.errorCode = errorCode;
+    this.detailMessage = detailMessage;
+  }
+}

--- a/src/main/java/com/team3/otboo/global/exception/ErrorCode.java
+++ b/src/main/java/com/team3/otboo/global/exception/ErrorCode.java
@@ -1,0 +1,24 @@
+package com.team3.otboo.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+  // Common Errors (Cxxx)
+  INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "입력값이 올바르지 않습니다."),
+  METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C002", "허용되지 않은 HTTP 메서드입니다."),
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C003", "서버 내부 오류가 발생했습니다."),
+  INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "C004", "요청 값의 타입이 올바르지 않습니다."),
+  ACCESS_DENIED(HttpStatus.FORBIDDEN, "C005", "접근 권한이 없습니다."),
+
+  // User Errors (Uxxx)
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "해당 사용자를 찾을 수 없습니다.");
+
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
+
+}

--- a/src/main/java/com/team3/otboo/global/exception/ErrorResponse.java
+++ b/src/main/java/com/team3/otboo/global/exception/ErrorResponse.java
@@ -1,0 +1,51 @@
+package com.team3.otboo.global.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+
+@JsonInclude(JsonInclude.Include.NON_NULL) // null인 필드는 JSON 응답에서 제외
+public record ErrorResponse(
+    LocalDateTime timestamp,
+    int status,
+    String error,
+    String code,
+    String message,
+    String path,
+    List<CustomFieldError> fieldErrors
+) {
+
+  public static ErrorResponse of(ErrorCode errorCode, String path) {
+    return new ErrorResponse(LocalDateTime.now(), errorCode.getStatus().value(), errorCode.getStatus().getReasonPhrase(),
+        errorCode.getCode(), errorCode.getMessage(), path, null);
+  }
+
+  public static ErrorResponse of(ErrorCode errorCode, String path, String customMessage) {
+    return new ErrorResponse(LocalDateTime.now(), errorCode.getStatus().value(), errorCode.getStatus().getReasonPhrase(),
+        errorCode.getCode(), customMessage != null ? customMessage : errorCode.getMessage(), path, null);
+  }
+
+  public static ErrorResponse of(ErrorCode errorCode, String path, BindingResult bindingResult) {
+    return new ErrorResponse(LocalDateTime.now(), errorCode.getStatus().value(), errorCode.getStatus().getReasonPhrase(),
+        errorCode.getCode(), errorCode.getMessage(), path, CustomFieldError.from(bindingResult));
+  }
+
+  public record CustomFieldError(
+      String field,
+      String value,
+      String reason
+  ) {
+    public static List<CustomFieldError> from(BindingResult bindingResult) {
+      final List<FieldError> errors = bindingResult.getFieldErrors();
+      return errors.stream()
+          .map(error -> new CustomFieldError(
+              error.getField(),
+              error.getRejectedValue() != null ? error.getRejectedValue().toString() : "",
+              error.getDefaultMessage()))
+          .collect(Collectors.toList());
+    }
+  }
+}

--- a/src/main/java/com/team3/otboo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/team3/otboo/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,37 @@
+package com.team3.otboo.global.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  protected ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException ex, HttpServletRequest request) {
+    log.warn("Validation failed: {} (request path: {})", ex.getMessage(), request.getRequestURI(), ex);
+    return new ResponseEntity<>(
+        ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, request.getRequestURI(), ex.getBindingResult()),
+        ErrorCode.INVALID_INPUT_VALUE.getStatus()
+    );
+  }
+
+  @ExceptionHandler(BusinessException.class)
+  protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException ex, HttpServletRequest request) {
+    log.warn("handleBusinessException: {} (request path: {})", ex.getMessage(), request.getRequestURI(), ex);
+    final ErrorCode errorCode = ex.getErrorCode();
+    final ErrorResponse response = ErrorResponse.of(errorCode, request.getRequestURI(), ex.getDetailMessage());
+    return new ResponseEntity<>(response, errorCode.getStatus());
+  }
+
+  @ExceptionHandler(Exception.class)
+  protected ResponseEntity<ErrorResponse> handleException(Exception ex, HttpServletRequest request) {
+    log.error("handleException: {} (request path: {})", ex.getMessage(), request.getRequestURI(), ex);
+    final ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR, request.getRequestURI());
+    return new ResponseEntity<>(response, ErrorCode.INTERNAL_SERVER_ERROR.getStatus());
+  }
+}

--- a/src/main/java/com/team3/otboo/global/exception/user/UserNotFoundException.java
+++ b/src/main/java/com/team3/otboo/global/exception/user/UserNotFoundException.java
@@ -1,0 +1,17 @@
+package com.team3.otboo.global.exception.user;
+
+
+import com.team3.otboo.global.exception.BusinessException;
+import com.team3.otboo.global.exception.ErrorCode;
+
+public class UserNotFoundException extends BusinessException {
+
+  public UserNotFoundException() {
+    super(ErrorCode.USER_NOT_FOUND, ErrorCode.USER_NOT_FOUND.getMessage());
+  }
+
+  public UserNotFoundException(String detailMessage) {
+    super(ErrorCode.USER_NOT_FOUND, detailMessage);
+  }
+
+}


### PR DESCRIPTION
#75 
설명
---
- GlobalExceptionHandler: 실제 예외들을 핸들링하는 핸들러입니다
- ErrorResonse: of를 통해 다양한 형식으로 에러를 보여줄 수 있습니다
- ErrrorCode(Enum): 커스텀을 해서 예외를 ENUM 타입으로 선언하시면 됩니다
- BusinessException: 모든 커스텀 예외의 부모입니다 Handler에서 관리하기 쉽도록 구현했습니다

사용방법
---
사용방법을 설명을 위해 UserNotFoundExcpetion 하나만 추가해뒀습니다
커밋내용에서 UserNotFoundException.java와 RecommendationService.java의 30~31번째 줄 확인 부탁드립니다