### PR TITLE
feat: 댓글 api (피드 댓글 조회, 피드 댓글 등록, 피드 댓글 삭제) 기능 구현

### DIFF
--- a/src/main/java/com/team3/otboo/domain/feed/controller/CommentController.java
+++ b/src/main/java/com/team3/otboo/domain/feed/controller/CommentController.java
@@ -1,0 +1,52 @@
+package com.team3.otboo.domain.feed.controller;
+
+import com.team3.otboo.domain.feed.dto.CommentDto;
+import com.team3.otboo.domain.feed.dto.CommentDtoCursorResponse;
+import com.team3.otboo.domain.feed.service.CommentService;
+import com.team3.otboo.domain.feed.service.request.CommentCreateRequest;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class CommentController {
+
+	private final CommentService commentService;
+
+	@GetMapping("/api/feeds/{feedId}/comments")
+	public ResponseEntity<CommentDtoCursorResponse> getComments(
+		@PathVariable UUID feedId,
+		@RequestParam(required = false) String cursor,
+		@RequestParam(required = false) UUID idAfter,
+		@RequestParam(defaultValue = "10") int limit
+	) {
+		CommentDtoCursorResponse response =
+			commentService.getComments(feedId, cursor, idAfter, limit);
+
+		return ResponseEntity.ok(response);
+	}
+
+	@PostMapping("/api/feeds/{feedId}/comments")
+	public ResponseEntity<CommentDto> create(
+		@RequestBody CommentCreateRequest request
+	) {
+		CommentDto commentDto = commentService.create(request);
+
+		return ResponseEntity.ok(commentDto);
+	}
+
+	@DeleteMapping("/api/feeds/comments/{commentId}")
+	public void delete(
+		@PathVariable("feedId") UUID feedId,
+		@PathVariable("commentId") UUID commentId) {
+		commentService.delete(commentId);
+	}
+}

--- a/src/main/java/com/team3/otboo/domain/feed/dto/CommentDto.java
+++ b/src/main/java/com/team3/otboo/domain/feed/dto/CommentDto.java
@@ -1,11 +1,11 @@
 package com.team3.otboo.domain.feed.dto;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 public record CommentDto(
 	UUID id,
-	LocalDateTime createdAt,
+	Instant createdAt,
 	UUID feedId,
 	AuthorDto author,
 	String content

--- a/src/main/java/com/team3/otboo/domain/feed/entity/Comment.java
+++ b/src/main/java/com/team3/otboo/domain/feed/entity/Comment.java
@@ -3,19 +3,14 @@ package com.team3.otboo.domain.feed.entity;
 import com.team3.otboo.domain.base.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 
+// create index idx_feed_id_created_at on article(feed_id asc, created_at desc)
 @Table(name = "comments")
 @Entity
 @Getter
@@ -32,7 +27,7 @@ public class Comment extends BaseEntity {
 	@Column(nullable = false)
 	private String content;
 
-	public static Comment create(UUID feedId, UUID authorId, String content){
+	public static Comment create(UUID feedId, UUID authorId, String content) {
 		Comment comment = new Comment();
 		comment.feedId = feedId;
 		comment.authorId = authorId;

--- a/src/main/java/com/team3/otboo/domain/feed/entity/FeedCommentCount.java
+++ b/src/main/java/com/team3/otboo/domain/feed/entity/FeedCommentCount.java
@@ -1,0 +1,29 @@
+package com.team3.otboo.domain.feed.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Table(name = "feed_comment_count")
+@Entity
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FeedCommentCount {
+
+	@Id
+	private UUID feedId;
+	private Long commentCount;
+
+	public static FeedCommentCount init(UUID feedId, Long commentCount) {
+		FeedCommentCount feedCommentCount = new FeedCommentCount();
+		feedCommentCount.feedId = feedId;
+		feedCommentCount.commentCount = commentCount;
+		return feedCommentCount;
+	}
+}

--- a/src/main/java/com/team3/otboo/domain/feed/mapper/AuthorMapper.java
+++ b/src/main/java/com/team3/otboo/domain/feed/mapper/AuthorMapper.java
@@ -11,7 +11,7 @@ public class AuthorMapper {
 		return new AuthorDto(
 			user.getId(),
 			user.getUsername(),
-			user.getProfileImageUrl()
+			user.getProfile().getProfileImageUrl()
 		);
 	}
 }

--- a/src/main/java/com/team3/otboo/domain/feed/mapper/AuthorMapper.java
+++ b/src/main/java/com/team3/otboo/domain/feed/mapper/AuthorMapper.java
@@ -1,0 +1,17 @@
+package com.team3.otboo.domain.feed.mapper;
+
+import com.team3.otboo.domain.feed.dto.AuthorDto;
+import com.team3.otboo.domain.user.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthorMapper {
+
+	public AuthorDto toDto(User user) {
+		return new AuthorDto(
+			user.getId(),
+			user.getUsername(),
+			user.getProfileImageUrl()
+		);
+	}
+}

--- a/src/main/java/com/team3/otboo/domain/feed/mapper/CommentMapper.java
+++ b/src/main/java/com/team3/otboo/domain/feed/mapper/CommentMapper.java
@@ -1,0 +1,24 @@
+package com.team3.otboo.domain.feed.mapper;
+
+import com.team3.otboo.domain.feed.dto.CommentDto;
+import com.team3.otboo.domain.feed.entity.Comment;
+import com.team3.otboo.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CommentMapper {
+
+	private final AuthorMapper authorMapper;
+
+	public CommentDto toDto(Comment comment, User author) {
+		return new CommentDto(
+			comment.getId(),
+			comment.getCreatedAt(),
+			comment.getFeedId(),
+			authorMapper.toDto(author),
+			comment.getContent()
+		);
+	}
+}

--- a/src/main/java/com/team3/otboo/domain/feed/repository/CommentRepository.java
+++ b/src/main/java/com/team3/otboo/domain/feed/repository/CommentRepository.java
@@ -1,0 +1,44 @@
+package com.team3.otboo.domain.feed.repository;
+
+import com.team3.otboo.domain.feed.entity.Comment;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, UUID> {
+
+	@Query(
+		value = "select c.id, c.created_at, c.updated_at, c.feed_id, c.author_id, c.content "
+			+ "from comments c "
+			+ "where c.feed_id = :feedId "
+			+ "order by c.created_at ASC, c.id ASC "
+			+ "limit :limit",
+		nativeQuery = true
+	)
+	List<Comment> findAll(
+		@Param("feedId") UUID feedId,
+		@Param("limit") Integer limit
+	);
+
+	@Query(
+		value = "select c.id, c.created_at, c.updated_at, c.feed_id, c.author_id, c.content "
+			+ "from comments c "
+			+ "where c.feed_id = :feedId "
+			+ "and (c.created_at > :createdAt or " // 값이 큰 데이터가 다음에 오는 데이터
+			+ "(c.created_at = :createdAt and c.id > :idAfter)"
+			+ ") order by c.created_at ASC, c.id ASC "
+			+ "limit :limit",
+		nativeQuery = true
+	)
+	List<Comment> findAll(
+		@Param("feedId") UUID feedId,
+		@Param("createdAt") Instant createdAt, // cursor
+		@Param("idAfter") UUID idAfter, // lastCommentId,
+		@Param("limit") Integer limit
+	);
+}

--- a/src/main/java/com/team3/otboo/domain/feed/repository/FeedCommentCountRepository.java
+++ b/src/main/java/com/team3/otboo/domain/feed/repository/FeedCommentCountRepository.java
@@ -1,0 +1,27 @@
+package com.team3.otboo.domain.feed.repository;
+
+import com.team3.otboo.domain.feed.entity.FeedCommentCount;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FeedCommentCountRepository extends JpaRepository<FeedCommentCount, UUID> {
+
+	@Query(
+		value = "update feed_comment_count set comment_count = comment_count + 1 where feed_id = :feedId",
+		nativeQuery = true
+	)
+	@Modifying
+	int increase(@Param("feedId") UUID feedId);
+
+	@Query(
+		value = "update feed_comment_count set comment_count = comment_count - 1 where feed_id = :feedId",
+		nativeQuery = true
+	)
+	@Modifying
+	int decrease(@Param("feedId") UUID feedId);
+}

--- a/src/main/java/com/team3/otboo/domain/feed/service/CommentService.java
+++ b/src/main/java/com/team3/otboo/domain/feed/service/CommentService.java
@@ -1,0 +1,123 @@
+package com.team3.otboo.domain.feed.service;
+
+import com.team3.otboo.domain.feed.dto.CommentDto;
+import com.team3.otboo.domain.feed.dto.CommentDtoCursorResponse;
+import com.team3.otboo.domain.feed.entity.Comment;
+import com.team3.otboo.domain.feed.entity.FeedCommentCount;
+import com.team3.otboo.domain.feed.mapper.CommentMapper;
+import com.team3.otboo.domain.feed.repository.CommentRepository;
+import com.team3.otboo.domain.feed.repository.FeedCommentCountRepository;
+import com.team3.otboo.domain.feed.repository.FeedRepository;
+import com.team3.otboo.domain.feed.service.request.CommentCreateRequest;
+import com.team3.otboo.domain.user.entity.User;
+import com.team3.otboo.domain.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.query.SortDirection;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+	private final CommentRepository commentRepository;
+	private final FeedCommentCountRepository feedCommentCountRepository;
+
+	private final UserRepository userRepository;
+	private final FeedRepository feedRepository;
+	private final CommentMapper commentMapper;
+
+	@Transactional
+	public CommentDto create(CommentCreateRequest request) {
+		if (!feedRepository.existsById(request.feedId())) {
+			throw new IllegalArgumentException("feed not found. feed id: " + request.feedId());
+		}
+
+		User author = userRepository.findById(request.authorId()).orElseThrow(
+			() -> new EntityNotFoundException("user not found. user Id: " + request.authorId())
+		);
+
+		Comment comment = commentRepository.save(Comment.create(
+			request.feedId(),
+			request.authorId(),
+			request.content()
+		));
+
+		int result = feedCommentCountRepository.increase(request.feedId());
+		if (result == 0) { // 객체 없으면 생성해서 넣어주기 .
+			feedCommentCountRepository.save(
+				FeedCommentCount.init(request.feedId(), 1L)
+			);
+		}
+
+		return commentMapper.toDto(comment, author);
+	}
+
+	@Transactional
+	public void delete(UUID commentId) {
+		Comment comment = commentRepository.findById(commentId).orElseThrow(
+			() -> new IllegalArgumentException("comment not found. commentId: " + commentId)
+		);
+		feedCommentCountRepository.decrease(comment.getFeedId());
+		commentRepository.delete(comment);
+	}
+
+	@Transactional(readOnly = true)
+	public CommentDtoCursorResponse getComments(UUID feedId, String cursor, UUID idAfter,
+		int limit) {
+		Long count = feedCommentCountRepository.findById(feedId)
+			.map(FeedCommentCount::getCommentCount)
+			.orElse(0L);
+
+		int commentCount = count.intValue();
+
+		Instant lastCreatedAt = null;
+		if (cursor != null) {
+			lastCreatedAt = Instant.parse(cursor);
+		}
+
+		List<Comment> comments = cursor == null || idAfter == null ?
+			commentRepository.findAll(feedId, limit + 1) :
+			commentRepository.findAll(feedId, lastCreatedAt, idAfter, limit + 1);
+
+		boolean hasNext = comments.size() > limit;
+		List<Comment> currentPage = hasNext ? comments.subList(0, limit) : comments;
+
+		Set<UUID> authorIds = currentPage.stream()
+			.map(Comment::getAuthorId)
+			.collect(Collectors.toSet());
+
+		Map<UUID, User> userMap = userRepository.findAllById(authorIds).stream()
+			.collect(Collectors.toMap(User::getId, Function.identity()));
+
+		List<CommentDto> commentDtoList = currentPage.stream()
+			.map(comment -> {
+				User user = userMap.get(comment.getAuthorId());
+				if (user == null) {
+					throw new EntityNotFoundException("User not found: " + comment.getAuthorId());
+				}
+				return commentMapper.toDto(comment, user);
+			})
+			.collect(Collectors.toList());
+
+		String nextCursor = null;
+		UUID nextIdAfter = null;
+
+		if (hasNext && !comments.isEmpty()) {
+			Comment lastElements = comments.get(limit - 1);
+			nextCursor = lastElements.getCreatedAt().toString();
+			nextIdAfter = lastElements.getId();
+		}
+
+		return new CommentDtoCursorResponse(commentDtoList, nextCursor, nextIdAfter, hasNext,
+			commentCount, "createdAt", SortDirection.ASCENDING);
+	}
+}

--- a/src/main/java/com/team3/otboo/domain/follow/mapper/FollowMapper.java
+++ b/src/main/java/com/team3/otboo/domain/follow/mapper/FollowMapper.java
@@ -25,9 +25,9 @@ public class FollowMapper {
 		return new FollowDto(
 			follow.getId(),
 			new UserSummary(followee.getId(), followee.getUsername(),
-				followee.getProfileImageUrl()),
+				followee.getProfile().getProfileImageUrl()),
 			new UserSummary(follower.getId(), follower.getUsername(),
-				follower.getProfileImageUrl())
+				follower.getProfile().getProfileImageUrl())
 		);
 	}
 }

--- a/src/main/java/com/team3/otboo/domain/user/dto/UserSummary.java
+++ b/src/main/java/com/team3/otboo/domain/user/dto/UserSummary.java
@@ -13,7 +13,7 @@ public record UserSummary(
 		return new UserSummary(
 			user.getId(),
 			user.getUsername(),
-			user.getProfileImageUrl()
+			user.getProfile().getProfileImageUrl()
 		);
 	}
 }


### PR DESCRIPTION
### 📝 댓글(Comment) API 기능 구현

GET /api/feeds/{feedId}/comments

POST /api/feeds/{feedId}/comments

### 📌 개요
피드(Feed)에 대한 댓글 목록 조회 및 댓글 생성 API를 추가 구현함.

### 주요 변경 사항
GET /api/feeds/{feedId}/comments

커서 기반 페이지네이션(CURSOR 기반 페이징) 적용.

POST /api/feeds/{feedId}/comments

특정 피드에 댓글 생성 가능.

댓글 생성 시 FeedCommentCount 증가, 없으면 새로 생성. (대규모 트래픽에 대비하여 count 쿼리 말고 직접 FeedCommentCount 테이블을 생성하였습니다.)

### 상세 구현 내역
- CommentService: 댓글 생성, 삭제, 조회 로직 추가 및 개선
- CommentRepository: Native Query 활용, 커서/IDAfter 기반 페이징 메서드 두 가지 제공
- 댓글 작성 시 FeedCommentCount 업데이트 트랜잭션 처리
