### PR TITLE
feat: 댓글 data initializer 구현 

### DIFF
--- a/src/test/java/com/team3/otboo/domain/feed/comment/data/DataInitializer.java
+++ b/src/test/java/com/team3/otboo/domain/feed/comment/data/DataInitializer.java
@@ -1,0 +1,57 @@
+package com.team3.otboo.domain.feed.comment.data;
+
+import com.team3.otboo.domain.feed.entity.Comment;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest
+public class DataInitializer {
+
+	@PersistenceContext
+	EntityManager entityManager;
+	@Autowired
+	TransactionTemplate transactionTemplate;
+	CountDownLatch latch = new CountDownLatch(EXECUTE_COUNT);
+
+	static final int BULK_INSERT_SIZE = 2000;
+	static final int EXECUTE_COUNT = 6000;
+
+	// 고정 UUID들
+	private static final UUID FEED_ID = UUID.randomUUID();
+	private static final UUID AUTHOR_ID = UUID.randomUUID();
+
+	@Test
+	void initialize() throws InterruptedException {
+		ExecutorService executorService = Executors.newFixedThreadPool(10);
+		for (int i = 0; i < EXECUTE_COUNT; i++) {
+			executorService.submit(() -> {
+				insert();
+				latch.countDown();
+				System.out.println("latch.getCount() = " + latch.getCount());
+			});
+		}
+		latch.await();
+		executorService.shutdown();
+	}
+
+	void insert() {
+		transactionTemplate.executeWithoutResult(status -> {
+			for (int i = 0; i < BULK_INSERT_SIZE; i++) {
+				Comment comment = Comment.create(
+					FEED_ID,
+					AUTHOR_ID,
+					"content " + i
+				);
+				entityManager.persist(comment);
+			}
+		});
+	}
+}

--- a/src/test/java/com/team3/otboo/domain/feed/like/data/DataInitializer.java
+++ b/src/test/java/com/team3/otboo/domain/feed/like/data/DataInitializer.java
@@ -1,0 +1,71 @@
+package com.team3.otboo.domain.feed.like.data;
+
+import com.team3.otboo.domain.feed.entity.Like;
+import com.team3.otboo.domain.feed.service.LikeService;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest
+public class DataInitializer {
+
+	@PersistenceContext
+	EntityManager entityManager;
+
+	@Autowired
+	TransactionTemplate transactionTemplate;
+
+	@Autowired
+	LikeService likeService;
+
+	CountDownLatch latch = new CountDownLatch(EXECUTE_COUNT);
+
+	static final int BULK_INSERT_SIZE = 2000;
+	static final int EXECUTE_COUNT = 6000;
+
+	private static final UUID FEED_ID = UUID.randomUUID();
+
+	@Test
+	void initialize() throws InterruptedException {
+		System.out.println("=== 하나의 피드에 1200만개의 좋아요 생성 시작 ===");
+		System.out.println("Feed ID: " + FEED_ID);
+
+		ExecutorService executorService = Executors.newFixedThreadPool(10);
+		for (int i = 0; i < EXECUTE_COUNT; i++) {
+			executorService.submit(() -> {
+				insert();
+				latch.countDown();
+				System.out.println("latch.getCount() = " + latch.getCount());
+			});
+		}
+		latch.await();
+		executorService.shutdown();
+
+		System.out.println("=== 좋아요 데이터 생성 완료 ===");
+	}
+
+	void insert() {
+		transactionTemplate.executeWithoutResult(status -> {
+			for (int i = 0; i < BULK_INSERT_SIZE; i++) {
+				Like like = Like.create(
+					FEED_ID,
+					UUID.randomUUID()  // 매번 새로운 userId
+				);
+				entityManager.persist(like);
+
+				// 메모리 정리
+				if (i % 500 == 0) {
+					entityManager.flush();
+					entityManager.clear();
+				}
+			}
+		});
+	}
+}


### PR DESCRIPTION
## 📝 개요
피드 댓글 기능의 대용량 데이터 성능 테스트를 위한 DataInitializer 구현

## 🎯 목적
- 하나의 피드에 대해 1200만개의 댓글 데이터 생성
- 대용량 데이터 환경에서의 성능 테스트 준비

## 🔧 구현 내용
- **생성 데이터**: 12,000,000개 좋아요 (6000회 × 2000개씩)
- **동시성**: 10개 스레드 풀을 사용한 병렬 처리
- **메모리 최적화**: 500개마다 flush/clear로 메모리 관리
- **트랜잭션**: TransactionTemplate을 사용한 안전한 배치 처리

## 📊 성능 고려사항
- CountDownLatch를 활용한 멀티스레드 동기화
- 배치 단위 처리로 메모리 사용량 최적화
- EntityManager의 1차 캐시 정리로 OOM 방지

## ⚠️ 주의사항
- **테스트 환경 전용**: 프로덕션 환경에서 실행 금지
- 실행시간 약 15분 정도 소요

## 데이터 삽입 후 count 쿼리 실행 (1200만건의 댓글을 count 하는데 1.8초가 걸림)
<img width="463" height="118" alt="image" src="https://github.com/user-attachments/assets/d9869dd6-cbc9-489a-9b24-58c24ce2c217" />
