### PR TITLE
feat: redis pub/sub 기능을 활용한 direct message 기능 구현

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,3 +23,8 @@ services:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
     ports:
       - "${DB_PORT}:5432"
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"

--- a/src/main/java/com/team3/otboo/config/RedisConfig.java
+++ b/src/main/java/com/team3/otboo/config/RedisConfig.java
@@ -61,8 +61,7 @@ public class RedisConfig {
 	}
 
 	@Bean
-	public MessageListenerAdapter messageListenerAdapter(SubscribeService redisPubSubService,
-		SubscribeService subscribeService) {
+	public MessageListenerAdapter messageListenerAdapter(SubscribeService subscribeService) {
 		return new MessageListenerAdapter(subscribeService, "onMessage");
 
 	}

--- a/src/main/java/com/team3/otboo/config/RedisConfig.java
+++ b/src/main/java/com/team3/otboo/config/RedisConfig.java
@@ -1,0 +1,69 @@
+package com.team3.otboo.config;
+
+import com.team3.otboo.domain.dm.service.SubscribeService;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+
+	@Value("${spring.data.redis.host}")
+	private String host;
+	@Value("${spring.data.redis.port}")
+	private int port;
+
+	@Bean
+	@Qualifier("chatPubSub")
+	public RedisConnectionFactory chatPubSubFactory() {
+		RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
+		configuration.setHostName(host);
+		configuration.setPort(port);
+		return new LettuceConnectionFactory(configuration);
+	}
+
+	// publish 객체 .
+	@Bean
+	@Qualifier("chatPubSub")
+	public RedisTemplate<String, Object> redisTemplate(
+		@Qualifier("chatPubSub") RedisConnectionFactory redisConnectionFactory) {
+		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory);
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+		return redisTemplate;
+	}
+
+	@Bean
+	public RedisMessageListenerContainer redisMessageListenerContainer(
+		@Qualifier("chatPubSub") RedisConnectionFactory redisConnectionFactory,
+		MessageListenerAdapter messageListenerAdapter
+	) {
+		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+		container.setConnectionFactory(redisConnectionFactory);
+		container.addMessageListener(
+			messageListenerAdapter,
+			new PatternTopic("direct-messages") // 수신 엔드 포인트 .
+		);
+		return container;
+	}
+
+	@Bean
+	public MessageListenerAdapter messageListenerAdapter(SubscribeService redisPubSubService,
+		SubscribeService subscribeService) {
+		return new MessageListenerAdapter(subscribeService, "onMessage");
+
+	}
+}

--- a/src/main/java/com/team3/otboo/config/RedisConfig.java
+++ b/src/main/java/com/team3/otboo/config/RedisConfig.java
@@ -63,6 +63,5 @@ public class RedisConfig {
 	@Bean
 	public MessageListenerAdapter messageListenerAdapter(SubscribeService subscribeService) {
 		return new MessageListenerAdapter(subscribeService, "onMessage");
-
 	}
 }

--- a/src/main/java/com/team3/otboo/domain/dm/config/WebSocketConfig.java
+++ b/src/main/java/com/team3/otboo/domain/dm/config/WebSocketConfig.java
@@ -1,0 +1,82 @@
+package com.team3.otboo.domain.dm.config;
+
+import com.team3.otboo.domain.dm.interceptor.HttpHandshakeInterceptor;
+import com.team3.otboo.domain.dm.interceptor.WebSocketChannelInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+	private final HttpHandshakeInterceptor handShakeInterceptor;
+	private final WebSocketChannelInterceptor channelInterceptor;
+
+	@Override
+	public void configureMessageBroker(MessageBrokerRegistry registry) {
+		registry.enableSimpleBroker("/sub"); // 메시지 수신 엔드 포인트
+		registry.setApplicationDestinationPrefixes("/pub"); // 메시지 송신 엔드 포인트
+	}
+
+	@Override
+	public void registerStompEndpoints(StompEndpointRegistry registry) {
+		registry.addEndpoint("/ws") // 웹소켓 연결 엔드 포인트 .
+			.setAllowedOriginPatterns("*") // cors 설정
+			.withSockJS();
+	}
+
+	@Override
+	public void configureClientInboundChannel(ChannelRegistration registration) {
+		registration.interceptors(channelInterceptor) // interceptor 설정 .
+			.taskExecutor(inboundChannelExecutor());
+		// 스레풀을 지정하지 않으면 Spring 이 스레드를 무제한으로 생성함 .
+	}
+
+	@Override
+	public void configureClientOutboundChannel(ChannelRegistration registration) {
+		registration.taskExecutor(outboundChannelExecutor());
+	}
+
+	@Bean("websocketTaskScheduler")
+	public TaskScheduler websocketTaskScheduler() {
+		ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+		scheduler.setPoolSize(Runtime.getRuntime().availableProcessors());
+		scheduler.setThreadNamePrefix("websocket-broker-");
+		scheduler.setWaitForTasksToCompleteOnShutdown(true);
+		scheduler.setAwaitTerminationSeconds(10);
+		scheduler.initialize();
+		return scheduler;
+	}
+
+	@Bean("websocketInboundExecutor")
+	public ThreadPoolTaskExecutor inboundChannelExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(8);
+		executor.setMaxPoolSize(16);
+		executor.setQueueCapacity(1000);
+		executor.setThreadNamePrefix("inbound-");
+		executor.initialize();
+		return executor;
+	}
+
+	@Bean("websocketOutboundExecutor")
+	public ThreadPoolTaskExecutor outboundChannelExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(8);
+		executor.setMaxPoolSize(16);
+		executor.setQueueCapacity(1000);
+		executor.setThreadNamePrefix("outbound-");
+		executor.initialize();
+		return executor;
+	}
+}

--- a/src/main/java/com/team3/otboo/domain/dm/controller/DirectMessageController.java
+++ b/src/main/java/com/team3/otboo/domain/dm/controller/DirectMessageController.java
@@ -18,7 +18,7 @@ public class DirectMessageController {
 	public DirectMessageDtoCursorResponse getMessages(
 		@RequestParam UUID userId
 	) {
-		// CustomUserDetails 구현 이후에 구현 ..
+		// CustomUserDetails 구현 이후에 구현
 		return null;
 	}
 }

--- a/src/main/java/com/team3/otboo/domain/dm/controller/DirectMessageController.java
+++ b/src/main/java/com/team3/otboo/domain/dm/controller/DirectMessageController.java
@@ -1,8 +1,24 @@
 package com.team3.otboo.domain.dm.controller;
 
+import com.team3.otboo.domain.dm.dto.DirectMessageDtoCursorResponse;
+import com.team3.otboo.domain.dm.service.DirectMessageService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 public class DirectMessageController {
 
+	private final DirectMessageService directMessageService;
+
+	@GetMapping("/api/direct-messages")
+	public DirectMessageDtoCursorResponse getMessages(
+		@RequestParam UUID userId
+	) {
+		// CustomUserDetails 구현 이후에 구현 ..
+		return null;
+	}
 }

--- a/src/main/java/com/team3/otboo/domain/dm/controller/StompController.java
+++ b/src/main/java/com/team3/otboo/domain/dm/controller/StompController.java
@@ -22,7 +22,7 @@ public class StompController {
 	public void sendDirectMessage(
 		@Payload DirectMessageCreateRequest request, Principal principal
 	) {
-		// 저장하고 레디스로 뿌려줌 .
+		// 저장하고 레디스로 전달
 		DirectMessageSendPayload payload = directMessageService.save(request);
 		publishService.publish(payload);
 	}

--- a/src/main/java/com/team3/otboo/domain/dm/controller/StompController.java
+++ b/src/main/java/com/team3/otboo/domain/dm/controller/StompController.java
@@ -1,0 +1,29 @@
+package com.team3.otboo.domain.dm.controller;
+
+import com.team3.otboo.domain.dm.dto.DirectMessageSendPayload;
+import com.team3.otboo.domain.dm.service.DirectMessageService;
+import com.team3.otboo.domain.dm.service.PublishService;
+import com.team3.otboo.domain.dm.service.request.DirectMessageCreateRequest;
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class StompController {
+
+	private final DirectMessageService directMessageService;
+	private final PublishService publishService;
+
+	// /pub/direct_messages_send 로 메시지 전송하면 여기로 온다.
+	@MessageMapping("/direct-messages_send")
+	public void sendDirectMessage(
+		@Payload DirectMessageCreateRequest request, Principal principal
+	) {
+		// 저장하고 레디스로 뿌려줌 .
+		DirectMessageSendPayload payload = directMessageService.save(request);
+		publishService.publish(payload);
+	}
+}

--- a/src/main/java/com/team3/otboo/domain/dm/dto/DirectMessageDto.java
+++ b/src/main/java/com/team3/otboo/domain/dm/dto/DirectMessageDto.java
@@ -1,12 +1,12 @@
 package com.team3.otboo.domain.dm.dto;
 
 import com.team3.otboo.domain.user.dto.UserSummary;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 public record DirectMessageDto(
 	UUID id,
-	LocalDateTime createdAt,
+	Instant createdAt,
 	UserSummary sender,
 	UserSummary receiver,
 	String content

--- a/src/main/java/com/team3/otboo/domain/dm/interceptor/HttpHandshakeInterceptor.java
+++ b/src/main/java/com/team3/otboo/domain/dm/interceptor/HttpHandshakeInterceptor.java
@@ -1,0 +1,36 @@
+package com.team3.otboo.domain.dm.interceptor;
+
+import com.team3.otboo.domain.user.jwt.JwtProvider;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+@Component
+@RequiredArgsConstructor
+public class HttpHandshakeInterceptor implements HandshakeInterceptor {
+
+	private final JwtProvider jwtProvider;
+
+	// TODO token provider 구현 후 token 검증 구현
+	@Override
+	public boolean beforeHandshake(
+		ServerHttpRequest request,
+		ServerHttpResponse response,
+		WebSocketHandler wsHandler,
+		Map<String, Object> attributes) throws Exception {
+
+		// 여기서 토큰 검증
+
+		return true;
+	}
+
+	@Override
+	public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
+		WebSocketHandler wsHandler, Exception exception) {
+
+	}
+}

--- a/src/main/java/com/team3/otboo/domain/dm/interceptor/WebSocketChannelInterceptor.java
+++ b/src/main/java/com/team3/otboo/domain/dm/interceptor/WebSocketChannelInterceptor.java
@@ -1,0 +1,10 @@
+package com.team3.otboo.domain.dm.interceptor;
+
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WebSocketChannelInterceptor implements ChannelInterceptor {
+
+	// 메시지 전송 전에 어떤 처리를 하고 싶으면 여기에 구현
+}

--- a/src/main/java/com/team3/otboo/domain/dm/mapper/DirectMessageMapper.java
+++ b/src/main/java/com/team3/otboo/domain/dm/mapper/DirectMessageMapper.java
@@ -1,0 +1,29 @@
+package com.team3.otboo.domain.dm.mapper;
+
+import com.team3.otboo.domain.dm.dto.DirectMessageDto;
+import com.team3.otboo.domain.dm.entity.DirectMessage;
+import com.team3.otboo.domain.user.dto.UserSummary;
+import com.team3.otboo.domain.user.entity.User;
+import com.team3.otboo.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DirectMessageMapper {
+
+	private final UserRepository userRepository;
+
+	// n+1 문제 해결해야함 .
+	public DirectMessageDto toDto(DirectMessage directMessage) {
+		User sender = userRepository.findById(directMessage.getSenderId()).orElse(null);
+		User receiver = userRepository.findById(directMessage.getReceiverId()).orElse(null);
+		return new DirectMessageDto(
+			directMessage.getId(),
+			directMessage.getCreatedAt(),
+			UserSummary.from(sender),
+			UserSummary.from(receiver),
+			directMessage.getContent()
+		);
+	}
+}

--- a/src/main/java/com/team3/otboo/domain/dm/repository/DirectMessageRepository.java
+++ b/src/main/java/com/team3/otboo/domain/dm/repository/DirectMessageRepository.java
@@ -1,8 +1,11 @@
 package com.team3.otboo.domain.dm.repository;
 
+import com.team3.otboo.domain.dm.entity.DirectMessage;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface DirectMessageRepository {
+public interface DirectMessageRepository extends JpaRepository<DirectMessage, UUID> {
 
 }

--- a/src/main/java/com/team3/otboo/domain/dm/service/DirectMessageService.java
+++ b/src/main/java/com/team3/otboo/domain/dm/service/DirectMessageService.java
@@ -1,8 +1,42 @@
 package com.team3.otboo.domain.dm.service;
 
+import com.team3.otboo.domain.dm.dto.DirectMessageSendPayload;
+import com.team3.otboo.domain.dm.entity.DirectMessage;
+import com.team3.otboo.domain.dm.mapper.DirectMessageMapper;
+import com.team3.otboo.domain.dm.repository.DirectMessageRepository;
+import com.team3.otboo.domain.dm.service.request.DirectMessageCreateRequest;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class DirectMessageService {
 
+	private final DirectMessageRepository directMessageRepository;
+	private DirectMessageMapper directMessageMapper;
+
+	public DirectMessageSendPayload save(DirectMessageCreateRequest request) {
+		String dmKey = createDmKey(request.senderId(), request.receiverId());
+
+		DirectMessage directMessage = directMessageRepository.save(
+			DirectMessage.create(
+				request.senderId(),
+				request.receiverId(),
+				request.content()
+			)
+		);
+		return new DirectMessageSendPayload(dmKey, directMessageMapper.toDto(directMessage));
+	}
+
+	// dm 목록 조회 .
+
+	private String createDmKey(UUID senderId, UUID receiverId) {
+		List<UUID> userIds = Arrays.asList(senderId, receiverId);
+		userIds.sort(Comparator.comparing(UUID::toString));
+		return userIds.get(0) + "_" + userIds.get(1);
+	}
 }

--- a/src/main/java/com/team3/otboo/domain/dm/service/PublishService.java
+++ b/src/main/java/com/team3/otboo/domain/dm/service/PublishService.java
@@ -1,0 +1,19 @@
+package com.team3.otboo.domain.dm.service;
+
+import com.team3.otboo.domain.dm.dto.DirectMessageSendPayload;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PublishService {
+
+	@Qualifier("chatPubSub")
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	public void publish(DirectMessageSendPayload payload) {
+		redisTemplate.convertAndSend("direct-messages", payload);
+	}
+}

--- a/src/main/java/com/team3/otboo/domain/dm/service/SubscribeService.java
+++ b/src/main/java/com/team3/otboo/domain/dm/service/SubscribeService.java
@@ -1,0 +1,35 @@
+package com.team3.otboo.domain.dm.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team3.otboo.domain.dm.dto.DirectMessageSendPayload;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SubscribeService implements MessageListener {
+
+	private final SimpMessageSendingOperations messageTemplate;
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void onMessage(Message message, byte[] pattern) {
+		try {
+			String publishMessage = new String(message.getBody());
+
+			DirectMessageSendPayload payload = objectMapper
+				.readValue(publishMessage, DirectMessageSendPayload.class);
+
+			messageTemplate.convertAndSend(
+				"/sub/direct-messages_" + payload.dmKey(),
+				payload);
+		} catch (Exception e) {
+			log.error("[SubscribeService.onMessage]json 역직렬화 중 오류 발생");
+		}
+	}
+}

--- a/src/main/java/com/team3/otboo/domain/dm/service/SubscribeService.java
+++ b/src/main/java/com/team3/otboo/domain/dm/service/SubscribeService.java
@@ -26,7 +26,7 @@ public class SubscribeService implements MessageListener {
 				.readValue(publishMessage, DirectMessageSendPayload.class);
 
 			messageTemplate.convertAndSend(
-				"/sub/direct-messages_" + payload.dmKey(),
+				"/sub/direct-messages_" + payload.dmKey(), // 수신 엔드포인트
 				payload);
 		} catch (Exception e) {
 			log.error("[SubscribeService.onMessage]json 역직렬화 중 오류 발생");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,6 @@
 spring:
   profiles:
     active: default
-
   datasource:
     url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:postgres}
     username: ${DB_USERNAME:root}
@@ -15,6 +14,10 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  data:
+    redis:
+      port: 6379
+      host: localhost
 
 server:
   port: 8080


### PR DESCRIPTION
## 개요 
Redis 의 pub/sub 기능을 활용하여 멀티 서버 환경에서도 메시지가 모든 서버에 전달 될 수 있도록 구현하였습니다.

## ⚠️ 주의 사항
 docker compose up 을 통해 redis 서버를 로컬에서 띄워야 코드를 실행할 수 있습니다. (docker compose 파일을 업로드 해두었습니다.)

## 설명
<img width="1000" height="500" alt="image" src="https://github.com/user-attachments/assets/ad624180-fdf8-4f8b-92a0-41bf5115eed6" />

웹 소켓 통신에서 특정 사용자는 서버의 메모리에 의존적이여서, 클라이언트 A가 발행한 메시지를 클라이언트B는 다른 서버에 연결되어 전달 받지 못하는 경우가 생김
→ 멀티 서버 환경에서 원할한 채팅을 전송을 위해 redis pub/sub 기능 사용

웹 소켓 서버는 메시지를 받아서 redis pub/sub 기능을 활용하여 모든 서버에 publish 함
모든 서버는 redis 에서 publish 한 메시지를 받아서 본인 서버의 topic 에 메시지를 발행함

1. @MessageMapping 으로 메시지 받고
2.  ChatService.pulish() 메서드 (convertAndSend) 를 통해 redis 에 메시지 전달하면,
3. Listener 가 듣고 있다가, 메시지 받아서 자신의 서버의 room 에 publish 해준다. (messageTemplate.convertAndSend() 메서드 사용)

redis 를 사용한 이유
rabbit mq, apache kafka 에 비해 장점.

1. 가벼움: 단순한 메시지 전달에 최적화
2. 빠름 : 인메모리 기반으로 낮은 지연 시간
3. 설정이 쉽다

- Redis는 더 빠른 성능 보장
    - kafka는 디스크에 메시지를 저장하는데 반해, redis는 저장하지 않고 메모리 기반의 db로 더 빠른 성능 보장, **메시지를 저장하지 않음**
- kafka는 더 안정적인 메시징 처리
    - redis는 pub/sub과정에서 메시지를 저장하지 않기에, listen하는 서버가 없다면 메시지가 유실되는데 반해, **kafka는 저장하여 추후에라도 전송 가능**