### PR TITLE
feat: dm 목록 조회 구현

### DIFF
--- a/src/main/java/com/team3/otboo/domain/dm/dto/DirectMessageDtoCursorResponse.java
+++ b/src/main/java/com/team3/otboo/domain/dm/dto/DirectMessageDtoCursorResponse.java
@@ -9,7 +9,7 @@ public record DirectMessageDtoCursorResponse(
 	String nextCursor,
 	UUID nextIdAfter,
 	boolean hasNext,
-	int totalCount,
+	int totalCount, // 두 사용자 간의 전체 DM 개수
 	String sortBy,
 	SortDirection sortDirection
 ) {

--- a/src/main/java/com/team3/otboo/domain/dm/entity/DirectMessage.java
+++ b/src/main/java/com/team3/otboo/domain/dm/entity/DirectMessage.java
@@ -3,20 +3,25 @@ package com.team3.otboo.domain.dm.entity;
 import com.team3.otboo.domain.base.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 
-@Table(name = "direct_messages")
+@Table(name = "direct_messages",
+	indexes = {
+		@Index(
+			name = "idx_dm_users_created_id_asc",
+			columnList = "sender_id, receiver_id, created_at, id"
+		),
+		@Index(
+			name = "idx_dm_users_reverse_created_id_asc",
+			columnList = "receiver_id, sender_id, created_at, id"
+		)
+	})
 @Entity
 @Getter
 @ToString
@@ -32,7 +37,7 @@ public class DirectMessage extends BaseEntity {
 	@Column(nullable = false)
 	private String content;
 
-	public static DirectMessage create(UUID senderId, UUID receiverId, String content){
+	public static DirectMessage create(UUID senderId, UUID receiverId, String content) {
 		DirectMessage directMessage = new DirectMessage();
 		directMessage.senderId = senderId;
 		directMessage.receiverId = receiverId;

--- a/src/main/java/com/team3/otboo/domain/dm/entity/DirectMessageCount.java
+++ b/src/main/java/com/team3/otboo/domain/dm/entity/DirectMessageCount.java
@@ -1,0 +1,28 @@
+package com.team3.otboo.domain.dm.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Table(name = "direct_message_count")
+@Entity
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DirectMessageCount {
+
+	@Id
+	private String dmKey;
+	private Long directMessageCount;
+
+	public static DirectMessageCount init(String dmKey, Long count) {
+		DirectMessageCount dmCount = new DirectMessageCount();
+		dmCount.dmKey = dmKey;
+		dmCount.directMessageCount = count;
+		return dmCount;
+	}
+}

--- a/src/main/java/com/team3/otboo/domain/dm/repository/DirectMessageCountRepository.java
+++ b/src/main/java/com/team3/otboo/domain/dm/repository/DirectMessageCountRepository.java
@@ -1,0 +1,26 @@
+package com.team3.otboo.domain.dm.repository;
+
+import com.team3.otboo.domain.dm.entity.DirectMessageCount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DirectMessageCountRepository extends JpaRepository<DirectMessageCount, String> {
+
+	@Query(
+		value = "update direct_message_count set direct_message_count = direct_message_count + 1 where dm_key = :dmKey ",
+		nativeQuery = true
+	)
+	@Modifying
+	int increase(@Param("dmKey") String dmKey);
+
+	@Query(
+		value = "update direct_message_count set direct_message_count = direct_message_count - 1 where dm_key = :dmKey",
+		nativeQuery = true
+	)
+	@Modifying
+	int decrease(@Param("dmKey") String dmKey);
+}

--- a/src/main/java/com/team3/otboo/domain/dm/repository/DirectMessageRepository.java
+++ b/src/main/java/com/team3/otboo/domain/dm/repository/DirectMessageRepository.java
@@ -1,11 +1,50 @@
 package com.team3.otboo.domain.dm.repository;
 
 import com.team3.otboo.domain.dm.entity.DirectMessage;
+import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface DirectMessageRepository extends JpaRepository<DirectMessage, UUID> {
 
+	@Query(
+		value = "select d.id, d.created_at, d.updated_at, d.sender_id, d.receiver_id, d.content "
+			+ "from direct_messages d "
+			+ "where ((d.sender_id = :userId and d.receiver_id = :currentUserId) "
+			+ "or (d.sender_id = :currentUserId and d.receiver_id = :userId)) "
+			+ "order by d.created_at asc, d.id asc "
+			+ "limit :limit"
+		,
+		nativeQuery = true
+	)
+	List<DirectMessage> getDirectMessages(
+		@Param("userId") UUID userId,
+		@Param("currentUserId") UUID currentUserId,
+		@Param("limit") int limit
+	);
+
+	@Query(
+		value =
+			"select d.id, d.created_at, d.updated_at, d.sender_id, d.receiver_id, d.content "
+				+ "from direct_messages d "
+				+ "where ((d.sender_id = :userId and d.receiver_id = :currentUserId) "
+				+ "or (d.sender_id = :currentUserId and d.receiver_id = :userId)) "
+				+ "and (d.created_at > :lastCreatedAt "
+				+ "or (d.created_at = :lastCreatedAt and d.id > :idAfter)) "
+				+ "order by d.created_at asc, d.id asc "
+				+ "limit :limit",
+		nativeQuery = true
+	)
+	List<DirectMessage> getDirectMessages(
+		@Param("userId") UUID userId,
+		@Param("currentUserId") UUID currentUserId,
+		@Param("lastCreatedAt") Instant lastCreatedAt,
+		@Param("idAfter") UUID idAfter,
+		@Param("limit") int limit
+	);
 }

--- a/src/main/java/com/team3/otboo/domain/dm/service/DirectMessageService.java
+++ b/src/main/java/com/team3/otboo/domain/dm/service/DirectMessageService.java
@@ -1,27 +1,33 @@
 package com.team3.otboo.domain.dm.service;
 
+import com.team3.otboo.domain.dm.dto.DirectMessageDto;
+import com.team3.otboo.domain.dm.dto.DirectMessageDtoCursorResponse;
 import com.team3.otboo.domain.dm.dto.DirectMessageSendPayload;
 import com.team3.otboo.domain.dm.entity.DirectMessage;
+import com.team3.otboo.domain.dm.entity.DirectMessageCount;
 import com.team3.otboo.domain.dm.mapper.DirectMessageMapper;
+import com.team3.otboo.domain.dm.repository.DirectMessageCountRepository;
 import com.team3.otboo.domain.dm.repository.DirectMessageRepository;
 import com.team3.otboo.domain.dm.service.request.DirectMessageCreateRequest;
-import java.util.Arrays;
-import java.util.Comparator;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.query.SortDirection;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class DirectMessageService {
 
 	private final DirectMessageRepository directMessageRepository;
-	private DirectMessageMapper directMessageMapper;
+	private final DirectMessageCountRepository directMessageCountRepository;
 
+	private final DirectMessageMapper directMessageMapper;
+
+	@Transactional
 	public DirectMessageSendPayload save(DirectMessageCreateRequest request) {
-		String dmKey = createDmKey(request.senderId(), request.receiverId());
-
 		DirectMessage directMessage = directMessageRepository.save(
 			DirectMessage.create(
 				request.senderId(),
@@ -29,14 +35,67 @@ public class DirectMessageService {
 				request.content()
 			)
 		);
+
+		String dmKey = createDmKey(request.senderId(), request.receiverId());
+		int result = directMessageCountRepository.increase(dmKey);
+		if (result == 0) {
+			directMessageCountRepository.save(DirectMessageCount.init(dmKey, 1L));
+		}
+
 		return new DirectMessageSendPayload(dmKey, directMessageMapper.toDto(directMessage));
 	}
 
-	// dm 목록 조회 .
+	public DirectMessageDtoCursorResponse getDirectMessages(UUID userId, UUID currentUserId,
+		String cursor, UUID idAfter, int limit) {
 
-	private String createDmKey(UUID senderId, UUID receiverId) {
-		List<UUID> userIds = Arrays.asList(senderId, receiverId);
-		userIds.sort(Comparator.comparing(UUID::toString));
-		return userIds.get(0) + "_" + userIds.get(1);
+		// count 쿼리 vs directMessageCountRepository 따로 만들기
+		// dm 은 쓰기 작업이 더 많을 거 같은데 count repository 만들면 쓸때마다 db 에 접근
+		// DirectMessageCount 를 레디스에 저장할까 ? cursor 페이지네이션 요청마다 count 해야함 .
+		String dmKey = createDmKey(userId, currentUserId);
+
+		Long count = directMessageCountRepository.findById(dmKey)
+			.map(DirectMessageCount::getDirectMessageCount)
+			.orElse(0L);
+		int totalCount = count.intValue();
+
+		Instant lastCreatedAt = null;
+		if (cursor != null) {
+			lastCreatedAt = Instant.parse(cursor);
+		}
+
+		List<DirectMessage> messages = cursor == null || idAfter == null ?
+			directMessageRepository.getDirectMessages(userId, currentUserId, limit + 1) :
+			directMessageRepository.getDirectMessages(userId, currentUserId,
+				lastCreatedAt, idAfter, limit + 1);
+
+		boolean hasNext = messages.size() > limit;
+		List<DirectMessage> currentPage = hasNext ? messages.subList(0, limit) : messages;
+
+		List<DirectMessageDto> directMessageDtoList = currentPage.stream()
+			.map(directMessageMapper::toDto)
+			.toList();
+
+		String nextCursor = null;
+		UUID nextIdAfter = null;
+		if (hasNext) {
+			DirectMessage lastElements = currentPage.getLast();
+			nextCursor = lastElements.getCreatedAt().toString();
+			nextIdAfter = lastElements.getId();
+		}
+
+		return new DirectMessageDtoCursorResponse(
+			directMessageDtoList,
+			nextCursor,
+			nextIdAfter,
+			hasNext,
+			totalCount,
+			"created_at, id",
+			SortDirection.ASCENDING
+		);
+	}
+
+	private String createDmKey(UUID userId1, UUID userId2) {
+		return userId1.compareTo(userId2) < 0 ?
+			userId1 + "_" + userId2 : userId2 + "_" + userId1;
 	}
 }

--- a/src/main/java/com/team3/otboo/domain/dm/service/SubscribeService.java
+++ b/src/main/java/com/team3/otboo/domain/dm/service/SubscribeService.java
@@ -21,7 +21,6 @@ public class SubscribeService implements MessageListener {
 	public void onMessage(Message message, byte[] pattern) {
 		try {
 			String publishMessage = new String(message.getBody());
-
 			DirectMessageSendPayload payload = objectMapper
 				.readValue(publishMessage, DirectMessageSendPayload.class);
 


### PR DESCRIPTION
## 개요
### dm 목록조회 구현

direct message의 totalCount 를 셀떼
direct_message_count 테이블 따로 만들기 vs direct_message 테이블에 직접 count 쿼리 사용하기



## COUNT 쿼리 vs count 테이블 따로 만들기
### COUNT 쿼리를 추천하는 경우
소규모 애플리케이션: 메시지 수가 수만 건 이하인 경우

데이터 정확성이 최우선: 실시간 정확한 카운트가 반드시 필요한 경우

단순한 요구사항: 기본적인 카운트만 필요한 경우

### 카운트 테이블을 따로 만드는 것을 추천하는 경우
대용량 데이터: 수십만 건 이상의 메시지를 처리하는 경우

빈번한 조회: 카운트 조회가 매우 자주 발생하는 경우
(현재의 경우 dm 창에서 cursor 페이징 요청을 할때마다 카운트 조회가 발생함)

## 결론
개인간의 DM이기 때문에 count 쿼리로도 충분히 성능이 나오기 때문에, 따로 count table 을 관리하는게 더 비효율적일 수도 있을 것 같습니다.

일단 count table 을 따로 만드는 방향으로 짰는데, 좀 더 생각해보고 수정을 진행하겠습니다.
