### PR TITLE
feat: 대량의 팔로워, 팔로우 data 삽입 기능 구현

### DIFF
--- a/src/main/java/com/team3/otboo/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/team3/otboo/domain/follow/controller/FollowController.java
@@ -5,11 +5,11 @@ import com.team3.otboo.domain.follow.dto.FollowSummaryDto;
 import com.team3.otboo.domain.follow.service.FollowService;
 import com.team3.otboo.domain.follow.service.request.FollowCreateRequest;
 import com.team3.otboo.domain.follow.service.response.FollowListResponse;
+import com.team3.otboo.domain.user.service.CustomUserDetailsService.CustomUserDetails;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -74,9 +74,11 @@ public class FollowController {
 	@GetMapping("/api/follows/summary")
 	public ResponseEntity<FollowSummaryDto> getFollowSummary(
 		@RequestParam("userId") UUID userId,
-		@AuthenticationPrincipal UserDetails userDetails
+		@AuthenticationPrincipal CustomUserDetails userDetails
 	) {
-
-		return null;
+		UUID currentUserId = userDetails.getId();
+		FollowSummaryDto response = followService.getFollowSummary(userId, currentUserId);
+		
+		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/team3/otboo/domain/follow/repository/UserFollowerCountRepository.java
+++ b/src/main/java/com/team3/otboo/domain/follow/repository/UserFollowerCountRepository.java
@@ -13,14 +13,14 @@ public interface UserFollowerCountRepository extends JpaRepository<UserFollowerC
 
 	// 대규모 트래픽이 예상되는 상황에서 팔로워, 팔로잉 수를 세는데 count 쿼리를 사용하면 너무 오래결럼 UserFollowerCount, UserFollowingCount 라는 객체를 따로 저장
 	@Query(
-		value = "update user_follower_count set follower_count = follower_count + 1 where userId = :userId",
+		value = "update user_follower_count set follower_count = follower_count + 1 where user_id = :userId",
 		nativeQuery = true
 	)
 	@Modifying
 	int increase(@Param("userId") UUID userId);
 
 	@Query(
-		value = "update user_following_count set following_count = following_count + 1 where userId = :userId",
+		value = "update user_following_count set following_count = following_count -1 where user_id = :userId",
 		nativeQuery = true
 	)
 	@Modifying

--- a/src/main/java/com/team3/otboo/domain/follow/service/FollowService.java
+++ b/src/main/java/com/team3/otboo/domain/follow/service/FollowService.java
@@ -203,7 +203,6 @@ public class FollowService {
 		);
 	}
 
-	// test 용 createBulk
 	@Transactional
 	public Follow createBulk(FollowCreateRequest request) {
 		Follow follow = followRepository.save(
@@ -212,7 +211,7 @@ public class FollowService {
 
 		// follower 의 following 카운트 증가
 		int followingResult = userFollowingCountRepository.increase(request.followerId());
-		if (followingResult == 0) {
+		if (followingResult == 0) { // 여러개 쓰레드로 접근하면 여기서 문제 생김 record 를 미리 만들어두던가 하면 된다
 			userFollowingCountRepository.save(
 				UserFollowingCount.init(request.followerId(), 1L)
 			);
@@ -220,7 +219,7 @@ public class FollowService {
 
 		// followee 의 follower 카운트 증가
 		int followerCount = userFollowerCountRepository.increase(request.followeeId());
-		if (followerCount == 0) {
+		if (followerCount == 0) { // 여러개 쓰레드로 접근하면 여기서 문제 생김
 			userFollowerCountRepository.save(
 				UserFollowerCount.init(request.followeeId(), 1L)
 			);

--- a/src/test/java/com/team3/otboo/domain/follow/data/FollowerDataInitializer.java
+++ b/src/test/java/com/team3/otboo/domain/follow/data/FollowerDataInitializer.java
@@ -1,0 +1,107 @@
+package com.team3.otboo.domain.follow.data;
+
+import com.team3.otboo.domain.follow.service.FollowService;
+import com.team3.otboo.domain.follow.service.request.FollowCreateRequest;
+import com.team3.otboo.domain.user.entity.Profile;
+import com.team3.otboo.domain.user.entity.User;
+import com.team3.otboo.domain.user.enums.Gender;
+import com.team3.otboo.domain.user.enums.Role;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.time.LocalDate;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest
+class FollowerBulkInitializer {
+
+	@PersistenceContext
+	EntityManager em;
+
+	@Autowired
+	TransactionTemplate tx;
+
+	@Autowired
+	FollowService followService;
+
+	private UUID targetUserId;
+
+	static final int FOLLOWER_SIZE = 2_000_000; // 200만 팔로워
+	static final int BATCH_SIZE = 500;
+	static final int THREAD_COUNT = 1;
+	static final int TASK_PER_THREAD = FOLLOWER_SIZE / THREAD_COUNT;
+
+	// 팔로워 받을 user 객체 1개 생성 .
+	@BeforeEach
+	void createTargetUser() {
+		tx.executeWithoutResult(status -> {
+			User target = User.builder()
+				.username("호날두")
+				.email("ronaldo@example.com")
+				.password("password")
+				.role(Role.USER)
+				.build();
+
+			target.setProfile(Profile.builder()
+				.user(target)
+				.gender(Gender.MALE)
+				.birthDate(LocalDate.of(1999, 1, 1))
+				.build());
+
+			em.persist(target);
+			em.flush();
+
+			targetUserId = target.getId();       // ★ 이 아이디가 followeeId
+		});
+	}
+
+	/* -------------------------------------------------------
+	   2) 20,000명의 팔로워 계정 + follow 레코드 생성
+	------------------------------------------------------- */
+	@Test
+	void initialize() throws InterruptedException {
+		ExecutorService pool = Executors.newFixedThreadPool(THREAD_COUNT);
+		CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
+
+		for (int t = 0; t < THREAD_COUNT; t++) {
+			pool.submit(() -> {
+				insert(TASK_PER_THREAD);
+				latch.countDown();
+			});
+		}
+
+		latch.await();
+		pool.shutdown();
+	}
+
+	private void insert(int count) {
+		tx.executeWithoutResult(status -> {
+			for (int i = 0; i < count; i++) {
+				User follower = User.builder()
+					.username("follower_" + UUID.randomUUID())
+					.email(UUID.randomUUID() + "@example.com")
+					.password("pw")
+					.role(Role.USER)
+					.build();
+				em.persist(follower);
+
+				followService.createBulk(new FollowCreateRequest(
+					targetUserId,
+					follower.getId()
+				));
+
+				if (i % BATCH_SIZE == 0) {
+					em.flush();
+					em.clear();
+				}
+			}
+		});
+	}
+}

--- a/src/test/java/com/team3/otboo/domain/follow/data/FollowerDataInitializer.java
+++ b/src/test/java/com/team3/otboo/domain/follow/data/FollowerDataInitializer.java
@@ -20,20 +20,20 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @SpringBootTest
-class FollowerBulkInitializer {
+class FollowerDataInitializer {
 
 	@PersistenceContext
-	EntityManager em;
+	EntityManager entityManager;
 
 	@Autowired
-	TransactionTemplate tx;
+	TransactionTemplate transactionTemplate;
 
 	@Autowired
 	FollowService followService;
 
-	private UUID targetUserId;
+	private UUID userId;
 
-	static final int FOLLOWER_SIZE = 2_000_000; // 200만 팔로워
+	static final int FOLLOWER_SIZE = 100;
 	static final int BATCH_SIZE = 500;
 	static final int THREAD_COUNT = 1;
 	static final int TASK_PER_THREAD = FOLLOWER_SIZE / THREAD_COUNT;
@@ -41,7 +41,7 @@ class FollowerBulkInitializer {
 	// 팔로워 받을 user 객체 1개 생성 .
 	@BeforeEach
 	void createTargetUser() {
-		tx.executeWithoutResult(status -> {
+		transactionTemplate.executeWithoutResult(status -> {
 			User target = User.builder()
 				.username("호날두")
 				.email("ronaldo@example.com")
@@ -52,13 +52,13 @@ class FollowerBulkInitializer {
 			target.setProfile(Profile.builder()
 				.user(target)
 				.gender(Gender.MALE)
-				.birthDate(LocalDate.of(1999, 1, 1))
+				.birthDate(LocalDate.of(2025, 8, 5))
 				.build());
 
-			em.persist(target);
-			em.flush();
+			entityManager.persist(target);
+			entityManager.flush();
 
-			targetUserId = target.getId();       // ★ 이 아이디가 followeeId
+			userId = target.getId();       // ★ 이 아이디가 followeeId
 		});
 	}
 
@@ -82,7 +82,7 @@ class FollowerBulkInitializer {
 	}
 
 	private void insert(int count) {
-		tx.executeWithoutResult(status -> {
+		transactionTemplate.executeWithoutResult(status -> {
 			for (int i = 0; i < count; i++) {
 				User follower = User.builder()
 					.username("follower_" + UUID.randomUUID())
@@ -90,16 +90,16 @@ class FollowerBulkInitializer {
 					.password("pw")
 					.role(Role.USER)
 					.build();
-				em.persist(follower);
+				entityManager.persist(follower);
 
 				followService.createBulk(new FollowCreateRequest(
-					targetUserId,
+					userId,
 					follower.getId()
 				));
 
 				if (i % BATCH_SIZE == 0) {
-					em.flush();
-					em.clear();
+					entityManager.flush();
+					entityManager.clear();
 				}
 			}
 		});

--- a/src/test/java/com/team3/otboo/domain/follow/data/FollowingDataInitializer.java
+++ b/src/test/java/com/team3/otboo/domain/follow/data/FollowingDataInitializer.java
@@ -2,19 +2,25 @@ package com.team3.otboo.domain.follow.data;
 
 import com.team3.otboo.domain.follow.service.FollowService;
 import com.team3.otboo.domain.follow.service.request.FollowCreateRequest;
+import com.team3.otboo.domain.user.entity.Profile;
+import com.team3.otboo.domain.user.entity.User;
+import com.team3.otboo.domain.user.enums.Gender;
+import com.team3.otboo.domain.user.enums.Role;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import java.time.LocalDate;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @SpringBootTest
-public class DataInitializer {
+public class FollowingDataInitializer {
 
 	@PersistenceContext
 	EntityManager entityManager;
@@ -27,17 +33,44 @@ public class DataInitializer {
 
 	CountDownLatch latch = new CountDownLatch(EXECUTE_COUNT);
 
-	static final int BULK_INSERT_SIZE = 2000;
-	static final int EXECUTE_COUNT = 6000; // 1200만개
+	static final int BULK_INSERT_SIZE = 20000;
+	static final int EXECUTE_COUNT = 1;
 
-	// 한 명의 슈퍼 팔로워
-	private static final UUID SUPER_FOLLOWER_ID = UUID.randomUUID();
+	private UUID userId;
 
+	@BeforeEach
+	void createTestUser() {
+		transactionTemplate.executeWithoutResult(status -> {
+			// User 먼저 생성
+			User user = User.builder()
+				.username("testUser")
+				.email("testuser@example.com")
+				.password("password123")
+				.role(Role.USER)
+				.build();
+
+			Profile profile = Profile.builder()
+				.user(user)
+				.gender(Gender.MALE)
+				.birthDate(LocalDate.of(2025, 8, 4))
+				.location(null)
+				.temperatureSensitivity(null)
+				.binaryContent(null)
+				.build();
+
+			user.setProfile(profile);
+
+			entityManager.persist(user);
+			entityManager.flush();
+			userId = user.getId();
+		});
+	}
+
+	/*
+		한사람이 20000명의 팔로잉을 갖게 하기
+	 */
 	@Test
 	void initialize() throws InterruptedException {
-		System.out.println("=== 한 사람이 1200만명 팔로우하는 데이터 생성 시작 ===");
-		System.out.println("Super Follower ID: " + SUPER_FOLLOWER_ID);
-
 		ExecutorService executorService = Executors.newFixedThreadPool(10);
 		for (int i = 0; i < EXECUTE_COUNT; i++) {
 			executorService.submit(() -> {
@@ -49,18 +82,16 @@ public class DataInitializer {
 		latch.await();
 		executorService.shutdown();
 
-		System.out.println("=== 팔로우 데이터 생성 완료 ===");
 	}
 
 	void insert() {
 		transactionTemplate.executeWithoutResult(status -> {
 			for (int i = 0; i < BULK_INSERT_SIZE; i++) {
-				// 매번 새로운 followee (팔로우 당하는 사람)
 				UUID followeeId = UUID.randomUUID();
 
 				FollowCreateRequest request = new FollowCreateRequest(
-					followeeId,        // 팔로우 당하는 사람 (매번 다름)
-					SUPER_FOLLOWER_ID  // 팔로우 하는 사람 (항상 같음)
+					followeeId,
+					userId
 				);
 
 				followService.createBulk(request);


### PR DESCRIPTION
## 개요
팔로워, 팔로우 data 삽입 기능 mock user 가 아닌 실제 user 객체를 생성하여 데이터를 삽입하도록 변경하였습니다.

<img width="222" height="64" alt="image" src="https://github.com/user-attachments/assets/9c7506d3-b904-4bc3-8761-1b3d77c63804" />

실행하실때 application.yml 파일에 show-sql 설정을 false로 하고 실행하면 부하를 줄일 수 있습니다.
## 결과
<img width="500" height="129" alt="user_id" src="https://github.com/user-attachments/assets/fd496197-ddbd-4957-aa3f-0a5a070e6d4c" />

2만명의 팔로워를 보유하고 있는 사용자

<img width="500" height="125" alt="Pasted Graphic 11" src="https://github.com/user-attachments/assets/0e1c8f16-2470-4e7b-8785-aaa65321b04b" />

2만명을 팔로우하고 있는 사용자


