### PR TITLE
feature: 외부 URL을 통한 의상 정보 자동 등록 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,13 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testCompileOnly 'org.projectlombok:lombok'      // 테스트용 Lombok
     testAnnotationProcessor 'org.projectlombok:lombok'
+
+    // langchain
+    implementation 'dev.langchain4j:langchain4j-core:0.36.2'
+    implementation 'dev.langchain4j:langchain4j-open-ai:0.36.2'
+
+    // 크롤링을 위한 jsoup
+    implementation 'org.jsoup:jsoup:1.17.2'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       DB_PASSWORD: ${DB_PASSWORD}
       REDIS_HOST: ${REDIS_HOST}
       REDIS_PORT: ${REDIS_PORT}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
     depends_on:
       - db
 

--- a/src/main/java/com/team3/otboo/domain/clothing/controller/ClothingController.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/controller/ClothingController.java
@@ -88,10 +88,4 @@ public class ClothingController {
         ClothingDto response = clothingService.updateClothing(clothesId, request, image);
         return ResponseEntity.ok(response);
     }
-
-//    @GetMapping("/extractions")
-//    public ResponseEntity<ClothingDto> extractClothingInfo(@RequestParam String url){
-//        ClothingDto dto = extractionsService.extractAndSave(url);
-//        return ResponseEntity.ok(dto);
-//    }
 }

--- a/src/main/java/com/team3/otboo/domain/clothing/controller/ClothingExtractionController.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/controller/ClothingExtractionController.java
@@ -1,0 +1,29 @@
+package com.team3.otboo.domain.clothing.controller;
+
+import com.team3.otboo.domain.clothing.dto.ClothingDto;
+import com.team3.otboo.domain.clothing.service.ClothingExtractionService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/clothes/extractions")
+public class ClothingExtractionController {
+
+    private final ClothingExtractionService extractionService;
+
+    @GetMapping
+    public ResponseEntity<ClothingDto> extractClothingInfo(
+            @RequestParam("url") String url
+//            ,@CurrentUser User user // 사용자 인증 정보를 가져온다고 가정
+    ) {
+        UUID fakeUserId = UUID.fromString("00000000-0000-0000-0000-000000000001"); // 테스트용 사용자 ID
+        ClothingDto clothingDto = extractionService.extractFromUrl(url, fakeUserId);
+        return ResponseEntity.ok(clothingDto);
+    }
+}

--- a/src/main/java/com/team3/otboo/domain/clothing/dto/ParsedClothingInfo.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/dto/ParsedClothingInfo.java
@@ -1,0 +1,7 @@
+package com.team3.otboo.domain.clothing.dto;
+
+public record ParsedClothingInfo(
+        String imageUrl,
+        String type,
+        String description
+) {}

--- a/src/main/java/com/team3/otboo/domain/clothing/parser/HtmlParser.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/parser/HtmlParser.java
@@ -1,0 +1,7 @@
+package com.team3.otboo.domain.clothing.parser;
+
+import com.team3.otboo.domain.clothing.dto.ParsedClothingInfo;
+
+public interface HtmlParser {
+    ParsedClothingInfo parse(String url);
+}

--- a/src/main/java/com/team3/otboo/domain/clothing/parser/JsoupHtmlParser.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/parser/JsoupHtmlParser.java
@@ -1,0 +1,35 @@
+package com.team3.otboo.domain.clothing.parser;
+
+import com.team3.otboo.domain.clothing.dto.ParsedClothingInfo;
+import com.team3.otboo.global.exception.BusinessException;
+import com.team3.otboo.global.exception.ErrorCode;
+import java.io.IOException;
+import java.util.Optional;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JsoupHtmlParser implements HtmlParser {
+
+    @Override
+    public ParsedClothingInfo parse(String url) {
+        try {
+            Document doc = Jsoup.connect(url)
+                    .userAgent("Mozilla/5.0")
+                    .timeout(5000)
+                    .get();
+
+            String imageUrl = Optional.ofNullable(doc.selectFirst("meta[property=og:image]"))
+                    .map(e -> e.attr("content")).orElse(null);
+
+            String description = Optional.ofNullable(doc.selectFirst("meta[property=og:description]"))
+                    .map(e -> e.attr("content")).orElse(doc.body().text());
+
+            return new ParsedClothingInfo(imageUrl, null, description);
+
+        } catch (IOException e) {
+            throw new BusinessException(ErrorCode.CLOTHING_EXTACTION_EXCEPTION);
+        }
+    }
+}

--- a/src/main/java/com/team3/otboo/domain/clothing/service/ClothingExtractionService.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/service/ClothingExtractionService.java
@@ -1,0 +1,8 @@
+package com.team3.otboo.domain.clothing.service;
+
+import com.team3.otboo.domain.clothing.dto.ClothingDto;
+import java.util.UUID;
+
+public interface ClothingExtractionService {
+    ClothingDto extractFromUrl(String url, UUID ownerId);
+}

--- a/src/main/java/com/team3/otboo/domain/clothing/service/ClothingExtractionServiceImpl.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/service/ClothingExtractionServiceImpl.java
@@ -1,0 +1,171 @@
+package com.team3.otboo.domain.clothing.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team3.otboo.domain.clothing.dto.ClothingAttributeWithDefDto;
+import com.team3.otboo.domain.clothing.dto.ClothingDto;
+import com.team3.otboo.domain.clothing.dto.ParsedClothingInfo;
+import com.team3.otboo.domain.clothing.entity.Attribute;
+import com.team3.otboo.domain.clothing.entity.AttributeOption;
+import com.team3.otboo.domain.clothing.parser.HtmlParser;
+import com.team3.otboo.domain.clothing.repository.AttributeRepository;
+import com.team3.otboo.global.exception.BusinessException;
+import com.team3.otboo.global.exception.ErrorCode;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class ClothingExtractionServiceImpl implements ClothingExtractionService {
+
+    private final HtmlParser htmlParser; // 파싱 전략
+    private final ObjectMapper objectMapper;
+    private final AttributeRepository attributeRepository;
+    private final OpenAiChatModel openAiChatModel;
+
+    public ClothingExtractionServiceImpl(
+            HtmlParser htmlParser,
+            ObjectMapper objectMapper,
+            AttributeRepository attributeRepository,
+            Environment env
+    ) {
+        this.htmlParser = htmlParser;
+        this.objectMapper = objectMapper;
+        this.attributeRepository = attributeRepository;
+
+        String apiKey = env.getProperty("openai.api.key", System.getenv("OPENAI_API_KEY"));
+        if (apiKey == null || apiKey.isBlank()) {
+            throw new IllegalArgumentException("OPENAI_API_KEY is missing!");
+        }
+
+        this.openAiChatModel = OpenAiChatModel.builder()
+                .apiKey(apiKey)
+                .modelName("gpt-4o-mini")
+                .temperature(0.1)         // 창의성 거의 없이 안정적인 응답
+                .topP(1.0)                // temperature 사용하므로 topP는 기본값
+                .maxTokens(512)           // 의상 정보만 추출하면 충분한 길이
+                .frequencyPenalty(0.0)    // 반복 억제할 필요 없음
+                .presencePenalty(0.0)     // 새로운 주제 도입 억제
+                .logRequests(true)
+                .logResponses(true)
+                .build();
+
+        log.info("OpenAIChatModel 초기화 완료");
+    }
+
+    @Override
+    public ClothingDto extractFromUrl(String url, UUID ownerId) {
+        // HTML 기반 기본 정보 추출
+        ParsedClothingInfo parsed = htmlParser.parse(url);
+        log.info("htmlParser로 추출한 정보 : {}", parsed.description());
+        String descriptionText = parsed.description();
+
+        // LLM 호출
+        String prompt = buildPrompt(descriptionText);
+        log.info("LLM 요청 프롬프트:\n{}", prompt);
+
+        String llmResponse = openAiChatModel.generate(prompt);
+        log.info("LLM 응답: {}", llmResponse);
+
+        try {
+            String json = extractJsonArray(llmResponse);
+            JsonNode root = objectMapper.readTree(json);
+
+            String name = root.get("name").asText();
+            String type = root.get("type").asText();
+            List<Map<String, String>> rawAttributes = objectMapper.convertValue(root.get("attributes"), new TypeReference<>() {});
+
+            List<ClothingAttributeWithDefDto> attributes = mapAttributes(rawAttributes);
+
+            return new ClothingDto(
+                    UUID.randomUUID(),  // 아직 저장 안된 상태니까 가짜 ID
+                    ownerId,
+                    name,
+                    parsed.imageUrl(),
+                    type,
+                    attributes
+            );
+        } catch (Exception e) {
+            log.error("LLM 응답 처리 실패", e);
+            // LLM을 제외한 정보 리턴
+            return new ClothingDto(UUID.randomUUID(), ownerId, null, parsed.imageUrl(), null, List.of());
+        }
+    }
+
+    // 프롬프트
+    private String buildPrompt(String desc) {
+        return """
+다음 상품 설명을 바탕으로 의류 정보를 추출해 주세요.
+
+JSON으로만 응답해야 하며, 아래 구조를 따라야 합니다.
+
+요구사항:
+- name은 제품의 대표명 또는 핵심 키워드로 지정하세요
+- type은 ["TOP", "BOTTOM", "OUTER", "DRESS", "SHOES", "ACCESSORY", "UNDERWEAR", "ETC"] 중 하나로 설정하세요
+- 브랜드, 제품번호 등 나머지 정보는 attributes에 포함하세요
+- 설명에 브랜드 이름이 포함되어 있다면 브랜드는 별도로 분리해서 attributes에 포함하세요
+
+예시:
+{
+  "name": "Signature Collar Detail Midi Jacket",
+  "type": "OUTER",
+  "attributes": [
+    {"definition": "브랜드", "value": "구호플러스"},
+    {"definition": "제품번호", "value": "KE5839M03D"},
+    {"definition": "색상", "value": "브라운"}
+  ]
+}
+
+설명:
+%s
+""".formatted(desc);
+    }
+
+    // 응답에서 JSON 추출
+    private String extractJsonArray(String llmResponse) {
+        int start = llmResponse.indexOf("{");
+        int end = llmResponse.lastIndexOf("}") + 1;
+
+        if (start == -1 || end == -1) {
+            throw new BusinessException(ErrorCode.LLM_JSON_NOT_FOUND);
+        }
+
+        return llmResponse.substring(start, end);
+    }
+
+    private List<ClothingAttributeWithDefDto> mapAttributes(List<Map<String, String>> parsed) {
+        Map<String, Attribute> definitionMap = attributeRepository.findAll().stream()
+                .collect(Collectors.toMap(Attribute::getName, Function.identity()));
+
+        List<ClothingAttributeWithDefDto> result = new ArrayList<>();
+
+        for (Map<String, String> entry : parsed) {
+            String def = entry.get("definition");
+            String value = entry.get("value");
+
+            Attribute attr = definitionMap.get(def);
+            if (attr == null) {
+                log.warn("정의되지 않은 속성: {}", def);
+                continue;
+            }
+
+            result.add(new ClothingAttributeWithDefDto(
+                    attr.getId(),
+                    attr.getName(),
+                    attr.getOptions().stream().map(AttributeOption::getValue).toList(),
+                    value
+            ));
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/team3/otboo/global/exception/ErrorCode.java
+++ b/src/main/java/com/team3/otboo/global/exception/ErrorCode.java
@@ -28,6 +28,9 @@ public enum ErrorCode {
   // Clothing Mapper Errors
   CLOTHING_MAPPER_CONVERSION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CL_M001", "DTO 변환에 실패했습니다."),
 
+  // Clothing Extraction Errors
+  CLOTHING_EXTACTION_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "CE001", "의상 정보 HTML 파싱 실패"),
+
   // Attribute Errors
   ATTRIBUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "ATTR001", "해당 속성을 찾을 수 없습니다."),
   ATTRIBUTE_NAME_DUPLICATED(HttpStatus.CONFLICT, "ATTR002", "이미 존재하는 속성명입니다."),
@@ -39,7 +42,10 @@ public enum ErrorCode {
   // Image Errors
   IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "IMG001", "이미지 업로드에 실패했습니다."),
   IMAGE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "IMG002", "이미지 삭제에 실패했습니다."),
-  INVALID_IMAGE_PATH(HttpStatus.FORBIDDEN, "IMG003", "유효하지 않은 이미지 경로입니다.");
+  INVALID_IMAGE_PATH(HttpStatus.FORBIDDEN, "IMG003", "유효하지 않은 이미지 경로입니다."),
+
+  // LLM Errors
+  LLM_JSON_NOT_FOUND(HttpStatus.BAD_REQUEST, "LLM001", "응답에 JSON이 포함되어 있지 않습니다.");
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,3 +36,7 @@ otboo:
       bucket: ${AWS_S3_BUCKET}
       baseUrl: ${AWS_S3_BUCKET_URL}
       presigned-url-expiration: ${AWS_S3_PRESIGNED_URL_EXPIRATION:600} # (기본값: 10분)
+
+openai:
+  api:
+    key: ${OPENAI_API_KEY}


### PR DESCRIPTION
## 구현내용
### 1. GET `/api/clothes/extractions`
- URL 파라미터로 받은 외부 쇼핑몰 링크를 기반으로, 의상 정보를 자동 추출합니다.
- 결과는 `ClothingDto` 형태로 반환되며, 추출된 속성 중 시스템에 정의된 속성과 매칭되는 항목만 포함됩니다.

### 2. Jsoup 기반 HTML 파서 (`HtmlParser`)
- 대부분의 쇼핑몰에서 제공하는 `og:image`, `og:description` 메타 태그를 추출합니다.
- `og:image` → `imageUrl`로 사용  
- `og:description` → LLM 프롬프트에 전달

### 3. LangChain + OpenAI GPT-4o-mini 연동
- 추출한 설명(description)을 기반으로 LLM에게 다음 정보를 요청합니다:
  - `name`: 대표 상품명
  - `type`: BOTTOM, TOP, OUTER 등 enum 값
  - `attributes`: 정의된 속성명(definition) + 값(value) 쌍
- 응답 JSON을 파싱하여 시스템 정의 속성과 매핑 후 DTO로 변환합니다.

## 설계 고려사항: 왜 Jsoup으로 먼저 전처리하나요?

LLM에게 웹사이트의 HTML 전체를 그대로 전달하면 비용 및 정확도 측면에서 비효율적입니다.

| 항목 | HTML 전체 전달 | Jsoup 전처리 후 전달 (현재 방식) |
|------|------------------|-----------------------------|
| 입력 토큰 수 | 수천~수만 | 100~300 |
| LLM 비용 | 수십~수백 원/건 | **약 5~7원/건** |
| 응답 속도 | 느림 (수 초 이상) | 빠름 (1~2초 이내) |
| 정확도 | 노이즈 많아 해석 실패 가능 | 핵심 내용만 포함해 정확도 ↑ |

따라서 이번 구현에서는 HTML에서 주요 메타 정보만 추출한 후,  
그 내용을 기반으로 LLM을 호출하는 **하이브리드 구조**를 채택했습니다.

## 참고사항
- `.env` 파일에 `OPENAI_API_KEY`를 설정해야 합니다.
- 현재는 사용자 인증 미적용 상태이며, 추후 `@CurrentUser` 방식으로 개선 예정입니다.
- HTML에서 추출되는 `og:description`만으로는 충분한 정보가 부족한 경우도 있어,
  추후 더 정교한 정보 추출 방식(추가 태그 탐색, 구조화된 영역 파싱 등)을 고려하고 있습니다.


## 스크린샷
[예시 사이트]
<img width="1534" height="1019" alt="image" src="https://github.com/user-attachments/assets/96669007-65b1-4df1-9d84-1ee91dd4b0d3" />

[api 호출결과]
<img width="712" height="653" alt="image" src="https://github.com/user-attachments/assets/05081152-8326-4dc9-bc08-a309b897dc31" />
- 현재 등록된 `attributes`가 없어 프론트에 표시되지 않고 있습니다.

## 관련 이슈
#119 