### PR TITLE
feat: direct message list 테스트 코드 작성

### DIFF
--- a/src/main/java/com/team3/otboo/domain/dm/service/DirectMessageService.java
+++ b/src/main/java/com/team3/otboo/domain/dm/service/DirectMessageService.java
@@ -77,7 +77,7 @@ public class DirectMessageService {
 
 		String nextCursor = null;
 		UUID nextIdAfter = null;
-		if (hasNext) {
+		if (hasNext && !currentPage.isEmpty()) {
 			DirectMessage lastElements = currentPage.getLast();
 			nextCursor = lastElements.getCreatedAt().toString();
 			nextIdAfter = lastElements.getId();

--- a/src/main/java/com/team3/otboo/domain/user/dto/UserSummary.java
+++ b/src/main/java/com/team3/otboo/domain/user/dto/UserSummary.java
@@ -1,6 +1,9 @@
 package com.team3.otboo.domain.user.dto;
 
+import com.team3.otboo.domain.user.entity.Profile;
 import com.team3.otboo.domain.user.entity.User;
+import com.team3.otboo.storage.entity.BinaryContent;
+import java.util.Optional;
 import java.util.UUID;
 
 public record UserSummary(
@@ -13,7 +16,10 @@ public record UserSummary(
 		return new UserSummary(
 			user.getId(),
 			user.getUsername(),
-			user.getProfile().getBinaryContent().getImageUrl()
+			Optional.ofNullable(user.getProfile())
+				.map(Profile::getBinaryContent)
+				.map(BinaryContent::getImageUrl)
+				.orElse(null)
 		);
 	}
 }

--- a/src/test/java/com/team3/otboo/domain/dm/api/DirectMessageApi.java
+++ b/src/test/java/com/team3/otboo/domain/dm/api/DirectMessageApi.java
@@ -1,0 +1,114 @@
+package com.team3.otboo.domain.dm.api;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.team3.otboo.domain.dm.dto.DirectMessageDto;
+import com.team3.otboo.domain.user.service.CustomUserDetailsService.CustomUserDetails;
+import java.util.List;
+import java.util.UUID;
+import lombok.Data;
+import org.hibernate.query.SortDirection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.client.RestClient;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class DirectMessageApi {
+
+	RestClient restClient = RestClient.create("http://localhost:8080");
+
+	@Autowired
+	MockMvc mockMvc;
+
+	private ObjectMapper objectMapper;
+
+	@BeforeEach
+	void setUp() {
+		objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+	}
+
+	@Test
+	void getDirectMessages() throws Exception {
+		// DataInitializer 에서 data 생성해서 실제 데이터베이스 user 테이블에 있는 userId를 넣어야함
+		UUID currentUserId = UUID.fromString("431c3108-c5da-4673-b4e9-9c711adb07d4");
+		UUID targetUserId = UUID.fromString("43d64e8d-e0e0-4848-938d-e01047901e10");
+
+		CustomUserDetails mockUserDetails = mock(CustomUserDetails.class);
+		when(mockUserDetails.getId()).thenReturn(currentUserId);
+		when(mockUserDetails.getUsername()).thenReturn("testUser");
+
+		// 첫번째 페이지 가져오기 .
+		MvcResult result = mockMvc.perform(get("/api/direct-messages")
+				.param("userId", targetUserId.toString())
+				.param("limit", "10")
+				.with(user(mockUserDetails)))
+			.andExpect(status().isOk())
+			.andReturn();
+
+		String responseBody = result.getResponse().getContentAsString();
+		DirectMessageDtoCursorResponse response = objectMapper.readValue(
+			responseBody, DirectMessageDtoCursorResponse.class
+		);
+
+		List<DirectMessageDto> data = response.getData();
+		System.out.println("[Message List]");
+		for (DirectMessageDto messageDto : data) {
+			System.out.println("content: " + messageDto.content());
+		}
+
+		DirectMessageDto lastElement = response.data.getLast();
+
+		String nextCursor = lastElement.createdAt().toString();
+		UUID nextIdAfter = lastElement.id();
+
+		System.out.println("nextCursor: " + nextCursor);
+		System.out.println("nextIdAfter: " + nextIdAfter);
+
+		// 두번째 페이지 가져오기 .
+		MvcResult result2 = mockMvc.perform(get("/api/direct-messages")
+				.param("userId", targetUserId.toString())
+				.param("limit", "10")
+				.param("cursor", nextCursor)
+				.param("idAfter", nextIdAfter.toString())
+				.with(user(mockUserDetails)))
+			.andExpect(status().isOk())
+			.andReturn();
+
+		String nextPageResponse = result2.getResponse().getContentAsString();
+		DirectMessageDtoCursorResponse response2 = objectMapper.readValue(
+			nextPageResponse, DirectMessageDtoCursorResponse.class
+		);
+
+		List<DirectMessageDto> data2 = response2.data;
+		for (DirectMessageDto directMessageDto : data2) {
+			System.out.println("content: " + directMessageDto.content());
+		}
+	}
+
+	@Data
+	public static class DirectMessageDtoCursorResponse {
+
+		private List<DirectMessageDto> data;
+		private String nextCursor;
+		private UUID nextIdAfter;
+		private boolean hasNext;
+		private int totalCount; // 두 사용자 간의 전체 DM 개수
+		private String sortBy;
+		private SortDirection sortDirection;
+	}
+}

--- a/src/test/java/com/team3/otboo/domain/dm/api/DirectMessageApi.java
+++ b/src/test/java/com/team3/otboo/domain/dm/api/DirectMessageApi.java
@@ -66,9 +66,10 @@ public class DirectMessageApi {
 		);
 
 		List<DirectMessageDto> data = response.getData();
-		System.out.println("[Message List]");
+		System.out.println("[First Page]");
 		for (DirectMessageDto messageDto : data) {
-			System.out.println("content: " + messageDto.content());
+			System.out.println("%s : content %s"
+				.formatted(messageDto.sender().userId(), messageDto.content()));
 		}
 
 		DirectMessageDto lastElement = response.data.getLast();
@@ -94,9 +95,11 @@ public class DirectMessageApi {
 			nextPageResponse, DirectMessageDtoCursorResponse.class
 		);
 
+		System.out.println("[Next Page]");
 		List<DirectMessageDto> data2 = response2.data;
-		for (DirectMessageDto directMessageDto : data2) {
-			System.out.println("content: " + directMessageDto.content());
+		for (DirectMessageDto messageDto : data2) {
+			System.out.println("%s : content %s"
+				.formatted(messageDto.sender().userId(), messageDto.content()));
 		}
 	}
 

--- a/src/test/java/com/team3/otboo/domain/dm/api/DirectMessageApi.java
+++ b/src/test/java/com/team3/otboo/domain/dm/api/DirectMessageApi.java
@@ -45,8 +45,8 @@ public class DirectMessageApi {
 	@Test
 	void getDirectMessages() throws Exception {
 		// DataInitializer 에서 data 생성해서 실제 데이터베이스 user 테이블에 있는 userId를 넣어야함
-		UUID currentUserId = UUID.fromString("431c3108-c5da-4673-b4e9-9c711adb07d4");
-		UUID targetUserId = UUID.fromString("43d64e8d-e0e0-4848-938d-e01047901e10");
+		UUID currentUserId = UUID.fromString("3accb62a-acbc-492a-b077-9e7d964f2e19");
+		UUID targetUserId = UUID.fromString("33bbc8a8-aaec-41d9-aa3e-5e8c9f3d453a");
 
 		CustomUserDetails mockUserDetails = mock(CustomUserDetails.class);
 		when(mockUserDetails.getId()).thenReturn(currentUserId);
@@ -69,7 +69,7 @@ public class DirectMessageApi {
 		System.out.println("[First Page]");
 		for (DirectMessageDto messageDto : data) {
 			System.out.println("%s : content %s"
-				.formatted(messageDto.sender().userId(), messageDto.content()));
+				.formatted(messageDto.sender().name(), messageDto.content()));
 		}
 
 		DirectMessageDto lastElement = response.data.getLast();
@@ -99,7 +99,7 @@ public class DirectMessageApi {
 		List<DirectMessageDto> data2 = response2.data;
 		for (DirectMessageDto messageDto : data2) {
 			System.out.println("%s : content %s"
-				.formatted(messageDto.sender().userId(), messageDto.content()));
+				.formatted(messageDto.sender().name(), messageDto.content()));
 		}
 	}
 

--- a/src/test/java/com/team3/otboo/domain/dm/data/DirectMessageDataInitializer.java
+++ b/src/test/java/com/team3/otboo/domain/dm/data/DirectMessageDataInitializer.java
@@ -30,8 +30,8 @@ public class DirectMessageDataInitializer {
 
 	CountDownLatch latch = new CountDownLatch(EXECUTE_COUNT);
 
-	static final int BULK_INSERT_SIZE = 200;
-	static final int EXECUTE_COUNT = 2; // 데이터 400개 생성
+	static final int BULK_INSERT_SIZE = 1000;
+	static final int EXECUTE_COUNT = 1; // 1000개의 dm 데이터 생성
 
 	private UUID senderId;
 	private UUID receiverId;

--- a/src/test/java/com/team3/otboo/domain/dm/data/DirectMessageDataInitializer.java
+++ b/src/test/java/com/team3/otboo/domain/dm/data/DirectMessageDataInitializer.java
@@ -42,7 +42,7 @@ public class DirectMessageDataInitializer {
 		transactionTemplate.executeWithoutResult(status -> {
 			// 첫 번째 유저 생성 (sender)
 			User sender = User.builder()
-				.username("senderUser")
+				.username("김태우")
 				.email("sender@example.com")
 				.password("password123")
 				.role(Role.USER.USER)
@@ -64,7 +64,7 @@ public class DirectMessageDataInitializer {
 
 			// 두 번째 유저 생성 (receiver)
 			User receiver = User.builder()
-				.username("receiverUser")
+				.username("김민식")
 				.email("receiver@example.com")
 				.password("password123")
 				.role(Role.USER)


### PR DESCRIPTION
## 개요

GET /api/direct-messages API 의 테스트 코드 작성하였습니다.
현재 로그인한 user 의 정보가 필요해서 실제 API 를 호출하지 않고 MockMvc 를 통해 HTTP 응답/요청 시뮬레이션을 진행했습니다.

테스트 진행시 DataInitializer 로 direct message 여러개와 user 객체 2개 생성 후
실제 데이터베이스에 있는 user 객체 2개를 각각 currentUserId, targetUserId 에 넣어야합니다.

## 결과
 
채팅방 cursor pagenation 결과

<img width="250" height="359" alt="image" src="https://github.com/user-attachments/assets/1b20e161-0ec0-4150-ba95-ade2d1a68556" />

<img width="250" height="354" alt="image" src="https://github.com/user-attachments/assets/713c4d0a-3133-4cdb-8dde-008df044773d" />

