### PR TITLE
Fix: Attribute name 매핑 누락 문제 수정

### DIFF
--- a/src/main/java/com/team3/otboo/domain/clothing/entity/Attribute.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/entity/Attribute.java
@@ -32,7 +32,7 @@ public class Attribute extends BaseEntity {
         this.options.add(option);
     }
 
-    public void updateName(String newName) {
+    public void setName(String newName) {
         this.name = newName;
     }
 

--- a/src/main/java/com/team3/otboo/domain/clothing/mapper/ClothingAttributeDefMapper.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/mapper/ClothingAttributeDefMapper.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Component;
 public interface ClothingAttributeDefMapper {
 
     // request → entity
+    @Mapping(target = "name", source = "name")
     @Mapping(target = "options", source = "selectableValues", qualifiedByName = "toOptions")
     Attribute toEntity(ClothingAttributeDefCreateRequest request);
 

--- a/src/main/java/com/team3/otboo/domain/clothing/service/ClothingAttributeDefServiceImpl.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/service/ClothingAttributeDefServiceImpl.java
@@ -6,6 +6,7 @@ import com.team3.otboo.domain.clothing.dto.response.CursorPageResponse;
 import com.team3.otboo.domain.clothing.entity.Attribute;
 import com.team3.otboo.domain.clothing.mapper.ClothingAttributeDefMapper;
 import com.team3.otboo.domain.clothing.repository.AttributeRepository;
+import com.team3.otboo.global.exception.attribute.AttributeNameDuplicatedException;
 import com.team3.otboo.global.exception.attribute.AttributeNotFoundException;
 import com.team3.otboo.global.exception.attribute.AttributeOptionEmptyException;
 import jakarta.transaction.Transactional;
@@ -25,7 +26,7 @@ public class ClothingAttributeDefServiceImpl implements ClothingAttributeDefServ
     @Transactional
     public ClothingAttributeDefDto create(ClothingAttributeDefCreateRequest request) {
         if (attributeRepository.existsByName(request.name())) {
-            throw new AttributeNotFoundException();
+            throw new AttributeNameDuplicatedException();
         }
 
         Attribute attribute = mapper.toEntity(request);
@@ -85,7 +86,7 @@ public class ClothingAttributeDefServiceImpl implements ClothingAttributeDefServ
         }
 
         // 이름 변경
-        attribute.updateName(request.name());
+        attribute.setName(request.name());
         attribute.replaceOptions(request.selectableValues());
 
         return mapper.toDto(attribute);


### PR DESCRIPTION
MapStruct에서 Attribute.name 필드가 매핑되지 않던 문제 해결했습니다.
기존 updateName → setName으로 변경하여 write accessor 제공하도록 변경하였습니다.