### PR TITLE
refactor: 서비스 로직의 중복 로직 제거, LocalImageStorage

### DIFF
--- a/src/main/java/com/team3/otboo/domain/clothing/entity/Clothing.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/entity/Clothing.java
@@ -36,17 +36,17 @@ public class Clothing extends BaseEntity {
         return clothing;
     }
 
-    public void updateImageUrl(String imageUrl) {
+    public void setUrl(String imageUrl) {
         this.imageUrl = imageUrl;
     }
 
-    public void updateOwner(User owner) {
+    public void setOwner(User owner) {
         this.owner = owner;
     }
 
-    public void updateName(String name) { this.name = name; }
+    public void setName(String name) { this.name = name; }
 
-    public void updateType(String type) { this.type = type; }
+    public void setType(String type) { this.type = type; }
 
     public void addAttributeValue(ClothingAttributeValue attributeValue) {
         this.attributeValues.add(attributeValue);

--- a/src/main/java/com/team3/otboo/domain/clothing/service/ClothingServiceImpl.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/service/ClothingServiceImpl.java
@@ -149,8 +149,7 @@ public class ClothingServiceImpl implements ClothingService {
         AttributeOption option = attributeOptionRepository.findByAttributeAndValue(attribute, attrDto.value())
                 .orElseThrow(AttributeOptionNotFoundException::new);
 
-        ClothingAttributeValue value = ClothingAttributeValue.of(clothing, attribute, option);
-        clothing.addAttributeValue(value);
+        ClothingAttributeValue.of(clothing, attribute, option);
       }
     }
 

--- a/src/main/java/com/team3/otboo/domain/clothing/service/ClothingServiceImpl.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/service/ClothingServiceImpl.java
@@ -15,12 +15,14 @@ import com.team3.otboo.domain.clothing.repository.AttributeOptionRepository;
 import com.team3.otboo.domain.clothing.repository.AttributeRepository;
 import com.team3.otboo.domain.clothing.repository.ClothingRepository;
 import com.team3.otboo.domain.user.entity.User;
+import com.team3.otboo.domain.user.repository.UserRepository;
 import com.team3.otboo.global.exception.BusinessException;
 import com.team3.otboo.global.exception.ErrorCode;
 import com.team3.otboo.global.exception.attribute.AttributeNotFoundException;
 import com.team3.otboo.global.exception.attributeoption.AttributeOptionNotFoundException;
 import com.team3.otboo.global.exception.clothing.ClothingNotFoundException;
 import com.team3.otboo.storage.ImageStorage;
+import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +42,7 @@ public class ClothingServiceImpl implements ClothingService {
   private final ImageStorage imageStorage;
   private final AttributeRepository attributeRepository;
   private final AttributeOptionRepository attributeOptionRepository;
+  private final UserRepository userRepository;
 
   @Override
   public List<Clothing> getClothesByOwner(User user) {
@@ -57,8 +60,8 @@ public class ClothingServiceImpl implements ClothingService {
     Clothing clothing = clothingMapper.toEntity(request);
 
     // 연관관계 세팅
-    clothing.updateOwner(user);           // 로그인 사용자
-    clothing.updateImageUrl(imageUrl);    // 업로드 url
+    clothing.setOwner(user);           // 로그인 사용자
+    clothing.setUrl(imageUrl);    // 업로드 url
 
     // attributeValues 직접 생성 및 연관관계 연결
     for (ClothingAttributeDto attrReq : request.attributes()) {
@@ -67,8 +70,7 @@ public class ClothingServiceImpl implements ClothingService {
       AttributeOption option = attributeOptionRepository.findByAttributeIdAndValue(attribute.getId(), attrReq.value())
               .orElseThrow(AttributeOptionNotFoundException::new);
 
-      ClothingAttributeValue cav = ClothingAttributeValue.of(clothing, attribute, option);
-      clothing.addAttributeValue(cav);
+      ClothingAttributeValue.of(clothing, attribute, option);
     }
 
     clothingRepository.save(clothing);
@@ -125,8 +127,8 @@ public class ClothingServiceImpl implements ClothingService {
             .orElseThrow(ClothingNotFoundException::new);
 
     // 기본 정보 업데이트
-    if (req.name() != null) clothing.updateName(req.name());
-    if (req.type() != null) clothing.updateType(req.type());
+    if (req.name() != null) clothing.setName(req.name());
+    if (req.type() != null) clothing.setType(req.type());
 
     if(image != null && !image.isEmpty()){
       // 기존 이미지 삭제
@@ -134,7 +136,7 @@ public class ClothingServiceImpl implements ClothingService {
         imageStorage.delete(clothing.getImageUrl());
       }
       String imageUrl = imageStorage.upload(image);
-      clothing.updateImageUrl(imageUrl);
+      clothing.setUrl(imageUrl);
     }
 
     // 속성 업데이트(전체 교체)

--- a/src/main/java/com/team3/otboo/storage/LocalImageStorage.java
+++ b/src/main/java/com/team3/otboo/storage/LocalImageStorage.java
@@ -25,7 +25,7 @@ public class LocalImageStorage implements ImageStorage {
     private final Path root;
 
     public LocalImageStorage(@Value("${otboo.storage.local.root-path}") Path root) {
-        this.root = root;
+        this.root = Paths.get(System.getProperty("user.dir")).resolve(root).toAbsolutePath();
     }
 
     @PostConstruct

--- a/src/test/java/com/team3/otboo/domain/clothing/service/ClothingServiceTest.java
+++ b/src/test/java/com/team3/otboo/domain/clothing/service/ClothingServiceTest.java
@@ -103,8 +103,8 @@ public class ClothingServiceTest {
             verify(attributeRepository).findById(attributeId);
             verify(attributeOptionRepository).findByAttributeIdAndValue(attributeId, "청색");
             verify(clothingMapper).toDto(mockClothing);
-            verify(mockClothing).updateOwner(mockUser);
-            verify(mockClothing).updateImageUrl(imageUrl);
+            verify(mockClothing).setOwner(mockUser);
+            verify(mockClothing).setUrl(imageUrl);
 
             assertThat(result).isNotNull();
             assertThat(result.name()).isEqualTo("청바지");
@@ -353,9 +353,9 @@ public class ClothingServiceTest {
 
             // then
             assertThat(result).isEqualTo(expectedDto);
-            verify(clothing).updateName("셔츠");
-            verify(clothing).updateType("TOP");
-            verify(clothing).updateImageUrl("/uploads/shirt.jpg");
+            verify(clothing).setName("셔츠");
+            verify(clothing).setType("TOP");
+            verify(clothing).setUrl("/uploads/shirt.jpg");
             verify(clothingRepository).findById(clothingId);
             verify(imageStorage).upload(image);
         }
@@ -377,8 +377,8 @@ public class ClothingServiceTest {
             ClothingDto result = clothingService.updateClothing(clothingId, request, image);
 
             // then
-            verify(clothing).updateName("셔츠");
-            verify(clothing).updateType("TOP");
+            verify(clothing).setName("셔츠");
+            verify(clothing).setType("TOP");
             verifyNoInteractions(imageStorage);
             verify(clothingMapper).toDto(clothing);
         }
@@ -403,7 +403,7 @@ public class ClothingServiceTest {
             // then
             verify(imageStorage).delete("/uploads/old.jpg");
             verify(imageStorage).upload(image);
-            verify(clothing).updateImageUrl("/uploads/shirt.jpg");
+            verify(clothing).setUrl("/uploads/shirt.jpg");
         }
 
         @DisplayName("updateClothing 성공 테스트 - 이미지 파일이 비어 있을 때 이미지 변경 무시")


### PR DESCRIPTION
- 원할한 Mapper 사용을 위하여 Clothing 엔티티의 updateField -> setField로 메서드 명 변경


- 기존 of 메서드에 연관관계 설정을 위한 addAttributeValue 메서드가 포함되어 있는데, 이후 중복 호출되어 제거
ex:
   ```
   ClothingAttributeValue cav = ClothingAttributeValue.of(clothing, attribute, option);
   clothing.addAttributeValue(cav);
   ```

- 환경변수가 설정되어 있지 않더라도 프로젝트 루트 디렉토리로 경로가 지정되도록 명시
  ```
  public LocalImageStorage(@Value("${otboo.storage.local.root-path}") Path root) {
        this.root = Paths.get(System.getProperty("user.dir")).resolve(root).toAbsolutePath();
    }
  ```