### PR TITLE
feat: 조회수 서비스 구현

### DIFF
--- a/src/main/java/com/team3/otboo/config/KafkaConfig.java
+++ b/src/main/java/com/team3/otboo/config/KafkaConfig.java
@@ -11,7 +11,7 @@ public class KafkaConfig {
 
 	// KafkaListenerContainer 카프카 메시지를 받아서 처리하는 작업자들을 관리하는 매니저
 	@Bean
-	public ConcurrentKafkaListenerContainerFactory<String, String> KafkaListenerContainerFactory(
+	public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
 		ConsumerFactory<String, String> consumerFactory
 	) {
 		ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();

--- a/src/main/java/com/team3/otboo/domain/feed/controller/ViewController.java
+++ b/src/main/java/com/team3/otboo/domain/feed/controller/ViewController.java
@@ -1,0 +1,37 @@
+package com.team3.otboo.domain.feed.controller;
+
+import com.team3.otboo.domain.feed.service.ViewService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class ViewController {
+
+	private final ViewService viewService;
+
+	@PostMapping("/api/feeds/{feedId}/view")
+	public ResponseEntity<Long> increase(
+		@PathVariable("feedId") UUID feedId
+	) {
+		log.info("[ViewController.increase()]");
+		Long count = viewService.increase(feedId);
+		return ResponseEntity.ok(count);
+	}
+
+	@GetMapping("/api/feeds/{feedId}/view")
+	public ResponseEntity<Long> count(
+		@PathVariable("feedId") UUID feedId
+	) {
+		log.info("[ViewController.count()]");
+		Long count = viewService.count(feedId);
+		return ResponseEntity.ok(count);
+	}
+}

--- a/src/main/java/com/team3/otboo/domain/feed/entity/FeedViewCount.java
+++ b/src/main/java/com/team3/otboo/domain/feed/entity/FeedViewCount.java
@@ -1,0 +1,29 @@
+package com.team3.otboo.domain.feed.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Table(name = "feed_view_count")
+@Entity
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FeedViewCount {
+
+	@Id
+	private UUID feedId;
+	private Long viewCount;
+
+	public static FeedViewCount init(UUID feedId, Long viewCount) {
+		FeedViewCount feedViewCount = new FeedViewCount();
+		feedViewCount.feedId = feedId;
+		feedViewCount.viewCount = viewCount;
+		return feedViewCount;
+	}
+}

--- a/src/main/java/com/team3/otboo/domain/feed/repository/FeedViewCountBackUpRepository.java
+++ b/src/main/java/com/team3/otboo/domain/feed/repository/FeedViewCountBackUpRepository.java
@@ -1,0 +1,25 @@
+package com.team3.otboo.domain.feed.repository;
+
+import com.team3.otboo.domain.feed.entity.FeedViewCount;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FeedViewCountBackUpRepository extends
+	JpaRepository<FeedViewCount, UUID> {
+
+	@Query(
+		value = "update feed_view_count set view_count = :viewCount "
+			+ "where feed_id = :feedId and view_count < :viewCount",
+		nativeQuery = true
+	)
+	@Modifying
+	int update(
+		@Param("feedId") UUID feedId,
+		@Param("viewCount") Long viewCount
+	);
+}

--- a/src/main/java/com/team3/otboo/domain/feed/repository/FeedViewCountRepository.java
+++ b/src/main/java/com/team3/otboo/domain/feed/repository/FeedViewCountRepository.java
@@ -1,0 +1,29 @@
+package com.team3.otboo.domain.feed.repository;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class FeedViewCountRepository {
+
+	private final StringRedisTemplate redisTemplate;
+
+	// view::feed::{feed_id}::view_count
+	private static final String KEY_FORMAT = "view::feed::%s::view_count";
+
+	public Long read(UUID feedId) {
+		String result = redisTemplate.opsForValue().get(generateKey(feedId));
+		return result == null ? 0L : Long.parseLong(result);
+	}
+
+	public Long increase(UUID feedId) {
+		return redisTemplate.opsForValue().increment(generateKey(feedId));
+	}
+
+	private String generateKey(UUID feedId) {
+		return KEY_FORMAT.formatted(feedId);
+	}
+}

--- a/src/main/java/com/team3/otboo/domain/feed/service/LikeService.java
+++ b/src/main/java/com/team3/otboo/domain/feed/service/LikeService.java
@@ -32,11 +32,11 @@ public class LikeService {
 	@Transactional
 	public FeedDto like(UUID userId, UUID feedId) {
 		User liker = userRepository.findById(userId)
-				.orElseThrow(UserNotFoundException::new);
+			.orElseThrow(UserNotFoundException::new);
 		Feed feed = feedRepository.findById(feedId)
-				.orElseThrow(UserNotFoundException::new);
+			.orElseThrow(UserNotFoundException::new);
 		User feedOwner = userRepository.findById(feed.getAuthorId())
-				.orElseThrow(UserNotFoundException::new);
+			.orElseThrow(UserNotFoundException::new);
 
 		likeRepository.save(
 			Like.create(

--- a/src/main/java/com/team3/otboo/domain/feed/service/ViewCountBackUpProcessor.java
+++ b/src/main/java/com/team3/otboo/domain/feed/service/ViewCountBackUpProcessor.java
@@ -1,0 +1,41 @@
+package com.team3.otboo.domain.feed.service;
+
+import com.team3.otboo.common.event.EventType;
+import com.team3.otboo.common.event.payload.FeedViewedEventPayload;
+import com.team3.otboo.domain.feed.entity.FeedViewCount;
+import com.team3.otboo.domain.feed.repository.FeedViewCountBackUpRepository;
+import com.team3.otboo.domain.hot.service.HotFeedOutboxEventPublisher;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class ViewCountBackUpProcessor {
+
+	private final HotFeedOutboxEventPublisher hotFeedOutboxEventPublisher;
+	private final FeedViewCountBackUpRepository feedViewCountBackUpRepository;
+
+	private final HotFeedOutboxEventPublisher outboxEventPublisher;
+
+	@Transactional
+	public void backUp(UUID feedId, Long viewCount) {
+		int result = feedViewCountBackUpRepository.update(feedId, viewCount);
+		if (result == 0) {
+			feedViewCountBackUpRepository.findById(feedId)
+				.ifPresentOrElse(ignored -> {
+					}, // 재확인 로직 .. 그사이에 누가 만들었을 수도 있으니까. (경쟁 상태 방어)
+					() -> feedViewCountBackUpRepository.save(FeedViewCount.init(feedId, viewCount))
+				);
+		}
+
+		outboxEventPublisher.publish(
+			EventType.FEED_VIEWED,
+			FeedViewedEventPayload.builder()
+				.feedId(feedId)
+				.feedViewCount(viewCount)
+				.build()
+		);
+	}
+}

--- a/src/main/java/com/team3/otboo/domain/feed/service/ViewService.java
+++ b/src/main/java/com/team3/otboo/domain/feed/service/ViewService.java
@@ -1,0 +1,28 @@
+package com.team3.otboo.domain.feed.service;
+
+import com.team3.otboo.domain.feed.repository.FeedViewCountRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ViewService {
+
+	private final FeedViewCountRepository feedViewCountRepository;
+	private final ViewCountBackUpProcessor viewCountBackUpProcessor;
+	
+	private static final int BACK_UP_BACH_SIZE = 100;
+
+	public Long increase(UUID feedId) {
+		Long count = feedViewCountRepository.increase(feedId);
+		if (count % BACK_UP_BACH_SIZE == 0) { // 100 단위마다 데이터베이스에 백업
+			viewCountBackUpProcessor.backUp(feedId, count);
+		}
+		return count;
+	}
+
+	public Long count(UUID feedId) {
+		return feedViewCountRepository.read(feedId);
+	}
+}

--- a/src/main/java/com/team3/otboo/domain/hot/service/HotFeedMessageRelay.java
+++ b/src/main/java/com/team3/otboo/domain/hot/service/HotFeedMessageRelay.java
@@ -46,7 +46,7 @@ public class HotFeedMessageRelay {
 				outbox.getPayload()
 			).get(1, TimeUnit.SECONDS); // 1초 동안 전송 완료 메시지를 기다림 .
 
-			outboxRepository.delete(outbox);
+			outboxRepository.delete(outbox); // 여기서 충돌 발생..
 		} catch (Exception e) {
 			log.error("[MessageRelay.publishEvent] outbox={}", outbox, e);
 		}

--- a/src/test/java/com/team3/otboo/domain/feed/view/api/ViewApiTest.java
+++ b/src/test/java/com/team3/otboo/domain/feed/view/api/ViewApiTest.java
@@ -1,0 +1,44 @@
+package com.team3.otboo.domain.feed.view.api;
+
+
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+public class ViewApiTest {
+
+	RestClient restClient = RestClient.create("http://localhost:8080");
+
+	@Test
+	void viewTest() throws InterruptedException {
+		ExecutorService executorService = Executors.newFixedThreadPool(100);
+		CountDownLatch latch = new CountDownLatch(10000);
+
+		UUID feedId = UUID.randomUUID();
+
+		for (int i = 0; i < 10000; i++) {
+			executorService.submit(() -> {
+				try {
+					restClient.post()
+						.uri("/api/feeds/{feedId}/view", feedId)
+						.retrieve()
+						.toBodilessEntity();
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		latch.await();
+
+		Long count = restClient.get()
+			.uri("/api/feeds/{feedId}/view", feedId)
+			.retrieve()
+			.body(Long.class);
+
+		System.out.println("count = " + count); // 한번 실행할때마다 view 가 100 씩 증가.
+	}
+}

--- a/src/test/java/com/team3/otboo/domain/feed/view/repository/FeedViewCountBackUpRepositoryTest.java
+++ b/src/test/java/com/team3/otboo/domain/feed/view/repository/FeedViewCountBackUpRepositoryTest.java
@@ -1,0 +1,52 @@
+package com.team3.otboo.domain.feed.view.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.team3.otboo.domain.feed.entity.FeedViewCount;
+import com.team3.otboo.domain.feed.repository.FeedViewCountBackUpRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+public class FeedViewCountBackUpRepositoryTest {
+
+	@Autowired
+	FeedViewCountBackUpRepository feedViewCountBackUpRepository;
+
+	@PersistenceContext
+	EntityManager entityManager;
+
+	@Test
+	@Transactional
+	void updateViewCountTest() {
+
+		UUID feedId = UUID.randomUUID();
+
+		feedViewCountBackUpRepository.save(
+			FeedViewCount.init(feedId, 0L)
+		);
+		entityManager.flush();
+		entityManager.clear();
+
+		// when
+		int result1 = feedViewCountBackUpRepository.update(feedId, 100L);
+		int result2 = feedViewCountBackUpRepository.update(feedId, 300L);
+		int result3 = feedViewCountBackUpRepository.update(feedId, 200L);
+
+		// then
+		assertThat(result1).isEqualTo(1); // 백업 성공
+		assertThat(result2).isEqualTo(1); // 백업 성공
+		assertThat(result3).isEqualTo(0);
+
+		Long backUpCount = feedViewCountBackUpRepository.findById(feedId)
+			.map(FeedViewCount::getViewCount)
+			.orElse(0L);
+
+		assertThat(backUpCount).isEqualTo(300L);
+	}
+}


### PR DESCRIPTION
## 조회수 서비스(View Service) 설계

조회수 특징 
댓글 수, 좋아요 수 처럼 다른 데이터의 개수로 파생되는 것이 아니므로 사용자는 누가 조회했는지 확인할 수 없고, 조회수만 볼 수 있습니다. 따라서 조회수는 데이터의 일관성이 비교적 중요하지 않습니다.

또한 트래픽이 아주 많을 수 있어, 빠르게 쓰기와 조회가 이루어져야한다는 특징이 있습니다.

그래서 조회수의 데이터베이스를 인메모리 데이터베이스인 Redis 로 채택하여 빠르게 읽고 쓸 수 있도록 하고, 
완전히 유실되어서는 안되므로 자체 백업 시스템으로 Postgres 에 개수 단위 (100개) 로 백업했습니다.

### 조회수 어뷰징 방지 정책

1. 조회수 증가 요청이 오면, Redis에 TTL을 설정한 후 데이터를 저장한다.
2. feedId + userId 를 조합하여 키를 만들고 이미 저장된 데이터가 있으면 조회수를 증가시키지 않는다.
