### PR TITLE
feat:  조회 쿼리를 elastic search로 처리하도록 변경

### DIFF
--- a/Dockerfile.elastic
+++ b/Dockerfile.elastic
@@ -1,0 +1,2 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.17.4
+RUN bin/elasticsearch-plugin install analysis-nori

--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     implementation 'org.jetbrains:annotations:24.0.1'
+
+    // Elastic Search
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+
+    // MongoDB
+//    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/team3/otboo/common/event/payload/FeedCreatedEventPayload.java
+++ b/src/main/java/com/team3/otboo/common/event/payload/FeedCreatedEventPayload.java
@@ -1,6 +1,8 @@
 package com.team3.otboo.common.event.payload;
 
 import com.team3.otboo.common.event.EventPayload;
+import com.team3.otboo.domain.weather.enums.PrecipitationType;
+import com.team3.otboo.domain.weather.enums.SkyStatus;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -20,4 +22,7 @@ public class FeedCreatedEventPayload implements EventPayload {
 	private UUID authorId;
 	private UUID weatherId;
 	private String content;
+
+	private SkyStatus skyStatus;
+	private PrecipitationType precipitationType;
 }

--- a/src/main/java/com/team3/otboo/config/ElasticSearchConfig.java
+++ b/src/main/java/com/team3/otboo/config/ElasticSearchConfig.java
@@ -1,0 +1,10 @@
+package com.team3.otboo.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+@Configuration
+@EnableElasticsearchRepositories(basePackages = "com.team3.otboo.domain.feedread.repository")
+public class ElasticSearchConfig {
+
+}

--- a/src/main/java/com/team3/otboo/config/SecurityConfig.java
+++ b/src/main/java/com/team3/otboo/config/SecurityConfig.java
@@ -1,21 +1,27 @@
 package com.team3.otboo.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.team3.otboo.domain.user.jwt.login.*;
 import com.team3.otboo.domain.user.enums.Role;
-import com.team3.otboo.domain.user.jwt.*;
+import com.team3.otboo.domain.user.jwt.JwtAuthenticationFilter;
+import com.team3.otboo.domain.user.jwt.JwtLogoutHandler;
+import com.team3.otboo.domain.user.jwt.JwtService;
+import com.team3.otboo.domain.user.jwt.login.CustomAuthenticationProvider;
+import com.team3.otboo.domain.user.jwt.login.CustomLoginFailureHandler;
+import com.team3.otboo.domain.user.jwt.login.JsonUsernamePasswordAuthenticationFilter;
+import com.team3.otboo.domain.user.jwt.login.JwtLoginSuccessHandler;
 import com.team3.otboo.domain.user.oauth.OAuth2LoginSuccessHandler;
 import com.team3.otboo.domain.user.user_details.CustomOAuthUserService;
+import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchyAuthoritiesMapper;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -28,6 +34,9 @@ import org.springframework.security.web.authentication.logout.HttpStatusReturnin
 import org.springframework.security.web.authentication.session.NullAuthenticatedSessionStrategy;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Slf4j
 @Configuration
@@ -35,120 +44,142 @@ import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 @EnableMethodSecurity // (Secured, PreAuthorize) 보안 어노테이션 활성화
 public class SecurityConfig {
 
-    @Bean
-    public SecurityFilterChain securityFilterChain(
-            HttpSecurity http,
-            ObjectMapper objectMapper,
-            DaoAuthenticationProvider daoAuthenticationProvider,
-            CustomAuthenticationProvider customAuthenticationProvider,
-            JwtService jwtService,
-            CustomOAuthUserService customOAuthUserService,
-            OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler
-    ) throws Exception {
-        // 인증 -> AuthenticationProvider
-        // 인가 -> 일부 URL은 허용, 나머지는 ADMIN 권한 필요
-        // CSRF -> 기본 활성화, 로그아웃은 예외처리
-        // 로그아웃 -> 세션 삭제 + 200 응답
-        // 로그인 필터 -> 기본 필터 대신 JSON기반 필터 사용
-        // 세션 관리 -> 세션 고정 공격 방지 + 동시 로그인 제한
-        http
-                // Http Security에 직접 provider 등록
-                .authenticationProvider(daoAuthenticationProvider)
-                .authenticationProvider(customAuthenticationProvider);
-        // Http Security로부터 빌드된 manager를 가져와 사용하겠다는 말
-        AuthenticationManager authenticationManager = http.getSharedObject(AuthenticationManager.class);
+	@Bean
+	public SecurityFilterChain securityFilterChain(
+		HttpSecurity http,
+		ObjectMapper objectMapper,
+		DaoAuthenticationProvider daoAuthenticationProvider,
+		CustomAuthenticationProvider customAuthenticationProvider,
+		JwtService jwtService,
+		CustomOAuthUserService customOAuthUserService,
+		OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler
+	) throws Exception {
+		// 인증 -> AuthenticationProvider
+		// 인가 -> 일부 URL은 허용, 나머지는 ADMIN 권한 필요
+		// CSRF -> 기본 활성화, 로그아웃은 예외처리
+		// 로그아웃 -> 세션 삭제 + 200 응답
+		// 로그인 필터 -> 기본 필터 대신 JSON기반 필터 사용
+		// 세션 관리 -> 세션 고정 공격 방지 + 동시 로그인 제한
+		http
+			// Http Security에 직접 provider 등록
+			.authenticationProvider(daoAuthenticationProvider)
+			.authenticationProvider(customAuthenticationProvider);
+		// Http Security로부터 빌드된 manager를 가져와 사용하겠다는 말
+		AuthenticationManager authenticationManager = http.getSharedObject(
+			AuthenticationManager.class);
 
-        http
-                // 인가 정책 설정
-                .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers(HttpMethod.POST, "/api/users").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/auth/csrf-token").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/auth/refresh").permitAll()
-                        .requestMatchers("/api/auth/sign-in/**").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/auth/reset-password").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/auth/me").permitAll()
-                        .requestMatchers("/uploads/**").permitAll() // 로컬 이미지 찾기 위한 url 경로 허용
-                        .requestMatchers("/actuator/health", "/actuator/health/**").permitAll() // 헬스체크 허용
-                        .requestMatchers(HttpMethod.GET, "/api/clothes/extractions").permitAll() // 임시 허용.
-                        .requestMatchers("/api/**").authenticated()
-                        .requestMatchers("/", "/assets/**", "/*.html", "/*.css", "/*.js", "/favicon.ico", "/*.png", "/ws/**").permitAll()
-                        .anyRequest().authenticated()
-                )
-                .csrf(csrf ->
-                        csrf
-                                // 로그아웃 요청에 대해 CSRF 보호를 비활성화 -> 빠른 처리를 위해
-                                // 웹소켓의 원활한 통신을 위해 추가
-                                .ignoringRequestMatchers("/ws/**", "/api/auth/sign-out")
-                                // 서버에서 생성한 CSRF 토큰을 쿠키에 저장하여 사용자에게 전달, JS에서 접근할 수 있게 함
-                                // XSRF-TOKEN, X-XSRF-TOKEN 자동 지정해줌
-                                .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-                                // CSRF 토큰을 요청(request) 속성에서도 사용할 수 있도록 설정
-                                .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())
-                                // CSRF 보호 기능이 불필요하게 세션을 생성하는 것을 방지
-                                .sessionAuthenticationStrategy(new NullAuthenticatedSessionStrategy())
-                )
-                .with(
-                        new JsonUsernamePasswordAuthenticationFilter.Configurer(objectMapper),
-                        configurer ->
-                                configurer
-                                        .successHandler(new JwtLoginSuccessHandler(objectMapper, jwtService))
-                                        .failureHandler(new CustomLoginFailureHandler(objectMapper))
-                )
-                // OAuth 로그인을 시도할 때, custom한걸 사용하도록
-                .oauth2Login(oauth -> oauth
-                        .userInfoEndpoint(userInfo -> userInfo
-                                .userService(customOAuthUserService))
-                        .successHandler(oAuth2LoginSuccessHandler)
-                )
-                .logout(logout ->
-                        logout
-                                // logout URL 경로 지정
-                                .logoutUrl("/api/auth/sign-out")
-                                // 로그아웃 성공 시 리다이렉트 대신 HTTP 200 OK 상태 코드만 반환
-                                .logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler())
-                                // JWT 무효화하는 로직 수행
-                                .addLogoutHandler(new JwtLogoutHandler(jwtService))
-                )
-                .sessionManagement(session ->
-                        session
-                                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtService, objectMapper),
-                        JsonUsernamePasswordAuthenticationFilter.class);
-        return http.build();
-    }
+		http
+			// 인가 정책 설정
+			.cors(Customizer.withDefaults())
+			.authorizeHttpRequests(authorize -> authorize
+				.requestMatchers(HttpMethod.POST, "/api/users").permitAll()
+				.requestMatchers(HttpMethod.GET, "/api/auth/csrf-token").permitAll()
+				.requestMatchers(HttpMethod.POST, "/api/auth/refresh").permitAll()
+				.requestMatchers("/api/auth/sign-in/**").permitAll()
+				.requestMatchers(HttpMethod.POST, "/api/auth/reset-password").permitAll()
+				.requestMatchers(HttpMethod.GET, "/api/auth/me").permitAll()
+				.requestMatchers("/uploads/**").permitAll() // 로컬 이미지 찾기 위한 url 경로 허용
+				.requestMatchers("/actuator/health", "/actuator/health/**").permitAll() // 헬스체크 허용
+				.requestMatchers(HttpMethod.GET, "/api/clothes/extractions").permitAll() // 임시 허용.
+				.requestMatchers("/api/**").authenticated()
+				.requestMatchers("/", "/assets/**", "/*.html", "/*.css", "/*.js", "/favicon.ico",
+					"/*.png", "/ws/**").permitAll()
+				.anyRequest().authenticated()
+			)
+			.csrf(csrf ->
+				csrf
+					// 로그아웃 요청에 대해 CSRF 보호를 비활성화 -> 빠른 처리를 위해
+					// 웹소켓의 원활한 통신을 위해 추가
+					.ignoringRequestMatchers("/ws/**", "/api/auth/sign-out")
+					// 서버에서 생성한 CSRF 토큰을 쿠키에 저장하여 사용자에게 전달, JS에서 접근할 수 있게 함
+					// XSRF-TOKEN, X-XSRF-TOKEN 자동 지정해줌
+					.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+					// CSRF 토큰을 요청(request) 속성에서도 사용할 수 있도록 설정
+					.csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())
+					// CSRF 보호 기능이 불필요하게 세션을 생성하는 것을 방지
+					.sessionAuthenticationStrategy(new NullAuthenticatedSessionStrategy())
+			)
+			.with(
+				new JsonUsernamePasswordAuthenticationFilter.Configurer(objectMapper),
+				configurer ->
+					configurer
+						.successHandler(new JwtLoginSuccessHandler(objectMapper, jwtService))
+						.failureHandler(new CustomLoginFailureHandler(objectMapper))
+			)
+			// OAuth 로그인을 시도할 때, custom한걸 사용하도록
+			.oauth2Login(oauth -> oauth
+				.userInfoEndpoint(userInfo -> userInfo
+					.userService(customOAuthUserService))
+				.successHandler(oAuth2LoginSuccessHandler)
+			)
+			.logout(logout ->
+				logout
+					// logout URL 경로 지정
+					.logoutUrl("/api/auth/sign-out")
+					// 로그아웃 성공 시 리다이렉트 대신 HTTP 200 OK 상태 코드만 반환
+					.logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler())
+					// JWT 무효화하는 로직 수행
+					.addLogoutHandler(new JwtLogoutHandler(jwtService))
+			)
+			.sessionManagement(session ->
+				session
+					.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+			)
+			.addFilterBefore(new JwtAuthenticationFilter(jwtService, objectMapper),
+				JsonUsernamePasswordAuthenticationFilter.class);
+		return http.build();
+	}
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
 
-    @Bean
-    public DaoAuthenticationProvider daoAuthenticationProvider(
-            UserDetailsService userDetailsService,
-            PasswordEncoder passwordEncoder,
-            RoleHierarchy roleHierarchy
-    ) {
-        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
-        provider.setUserDetailsService(userDetailsService);
-        provider.setPasswordEncoder(passwordEncoder);
-        provider.setAuthoritiesMapper(new RoleHierarchyAuthoritiesMapper(roleHierarchy));
-        return provider;
-    }
+	@Bean
+	public DaoAuthenticationProvider daoAuthenticationProvider(
+		UserDetailsService userDetailsService,
+		PasswordEncoder passwordEncoder,
+		RoleHierarchy roleHierarchy
+	) {
+		DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+		provider.setUserDetailsService(userDetailsService);
+		provider.setPasswordEncoder(passwordEncoder);
+		provider.setAuthoritiesMapper(new RoleHierarchyAuthoritiesMapper(roleHierarchy));
+		return provider;
+	}
 
-    @Bean
-    public CustomAuthenticationProvider customAuthenticationProvider(
-            UserDetailsService userDetailsService,
-            PasswordEncoder passwordEncoder
-    ) {
-        return new CustomAuthenticationProvider(userDetailsService, passwordEncoder);
-    }
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+		// 프론트엔드 주소를 정확하게 명시해야 합니다.
+		configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173"));
+		// 필요한 HTTP 메서드를 허용합니다.
+		configuration.setAllowedMethods(
+			Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+		// 모든 헤더를 허용합니다.
+		configuration.setAllowedHeaders(Arrays.asList("*"));
+		// ★★★ 이 설정이 쿠키 전송을 허용하는 핵심입니다.
+		configuration.setAllowCredentials(true);
 
-    @Bean
-    public RoleHierarchy roleHierarchy() {
-        return RoleHierarchyImpl.withDefaultRolePrefix()
-                .role(Role.ADMIN.name())
-                .implies(Role.USER.name())
-                .build();
-    }
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		// 모든 경로("/**")에 위 설정을 적용합니다.
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
+	}
+
+	@Bean
+	public CustomAuthenticationProvider customAuthenticationProvider(
+		UserDetailsService userDetailsService,
+		PasswordEncoder passwordEncoder
+	) {
+		return new CustomAuthenticationProvider(userDetailsService, passwordEncoder);
+	}
+
+	@Bean
+	public RoleHierarchy roleHierarchy() {
+		return RoleHierarchyImpl.withDefaultRolePrefix()
+			.role(Role.ADMIN.name())
+			.implies(Role.USER.name())
+			.build();
+	}
 }

--- a/src/main/java/com/team3/otboo/domain/feed/dto/FeedDto.java
+++ b/src/main/java/com/team3/otboo/domain/feed/dto/FeedDto.java
@@ -22,10 +22,7 @@ public record FeedDto(
 	// 바뀌는 데이터 -> content, likeCount, commentCount, likedByMe, viewCount
 ) {
 
-	public static FeedDto from(
-		FeedQueryModel feedQueryModel,
-		Long likeCount,
-		Long commentCount,
+	public static FeedDto from(FeedQueryModel feedQueryModel, Long likeCount, Long commentCount,
 		Boolean likedByMe) {
 		return new FeedDto(
 			feedQueryModel.getId(),

--- a/src/main/java/com/team3/otboo/domain/feed/repository/FeedLikeCountRepository.java
+++ b/src/main/java/com/team3/otboo/domain/feed/repository/FeedLikeCountRepository.java
@@ -1,6 +1,7 @@
 package com.team3.otboo.domain.feed.repository;
 
 import com.team3.otboo.domain.feed.entity.FeedLikeCount;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -34,4 +35,10 @@ public interface FeedLikeCountRepository extends JpaRepository<FeedLikeCount, UU
 	)
 	@Modifying
 	Long increaseAndGet(@Param("feedId") UUID feedId);
+
+	@Query(
+		value = "SELECT * FROM feed_like_count WHERE feed_id IN (:ids)",
+		nativeQuery = true
+	)
+	List<FeedLikeCount> findAllByIdIn(@Param("ids") List<UUID> ids);
 }

--- a/src/main/java/com/team3/otboo/domain/feed/repository/FeedRepository.java
+++ b/src/main/java/com/team3/otboo/domain/feed/repository/FeedRepository.java
@@ -1,6 +1,7 @@
 package com.team3.otboo.domain.feed.repository;
 
 import com.team3.otboo.domain.feed.entity.Feed;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,4 +19,16 @@ public interface FeedRepository extends JpaRepository<Feed, UUID> {
 	Optional<UUID> findAuthorIdById(
 		@Param("id") UUID feedId
 	);
+
+	/**
+	 * 주어진 UUID 목록에 해당하는 모든 Feed 엔티티를 조회합니다. Native SQL의 IN 절을 사용하여 한번의 쿼리로 모든 데이터를 가져옵니다.
+	 *
+	 * @param ids 조회할 Feed의 UUID 목록
+	 * @return 조회된 Feed 엔티티 목록
+	 */
+	@Query(
+		value = "SELECT * FROM feeds f WHERE f.id IN (:ids)",
+		nativeQuery = true
+	)
+	List<Feed> findAllByIdIn(@Param("ids") List<UUID> ids);
 }

--- a/src/main/java/com/team3/otboo/domain/feed/service/FeedService.java
+++ b/src/main/java/com/team3/otboo/domain/feed/service/FeedService.java
@@ -23,6 +23,8 @@ import com.team3.otboo.domain.feed.service.request.FeedUpdateRequest;
 import com.team3.otboo.domain.feed.service.response.FeedDtoCursorResponse;
 import com.team3.otboo.domain.user.entity.User;
 import com.team3.otboo.domain.user.repository.UserRepository;
+import com.team3.otboo.domain.weather.entity.Weather;
+import com.team3.otboo.domain.weather.repository.WeatherRepository;
 import com.team3.otboo.event.FollowedUserPostedFeedEvent;
 import com.team3.otboo.global.exception.user.UserNotFoundException;
 import jakarta.persistence.EntityNotFoundException;
@@ -56,6 +58,7 @@ public class FeedService {
 	private final FeedViewCountBackUpRepository feedViewCountBackUpRepository;
 
 	private final OutboxEventPublisher outboxEventPublisher;
+	private final WeatherRepository weatherRepository;
 
 	// 알림 기능과 겹치니까 publish 는 한번만 하고, Listener 를 두개 써야함 .
 	// 겹치는거 -> 좋아요 생성 삭제, 댓글 생성 시 알림 가야하고 + 인기 피드 쪽에서 점수 계산까지 해야함 .
@@ -85,6 +88,9 @@ public class FeedService {
 		}
 
 		log.info("[FeedService.create] feed created. feedId: " + feed.getId());
+		Weather weather = weatherRepository.findById(feed.getWeatherId())
+			.orElseThrow(EntityNotFoundException::new);
+
 		outboxEventPublisher.publish(
 			EventType.FEED_CREATED,
 			FeedCreatedEventPayload.builder()
@@ -94,6 +100,8 @@ public class FeedService {
 				.authorId(feed.getAuthorId())
 				.weatherId(feed.getWeatherId())
 				.content(feed.getContent())
+				.skyStatus(weather.getSkyStatus())
+				.precipitationType(weather.getPrecipitation().getType())
 				.build()
 		);
 

--- a/src/main/java/com/team3/otboo/domain/feed/service/LikeService.java
+++ b/src/main/java/com/team3/otboo/domain/feed/service/LikeService.java
@@ -18,12 +18,14 @@ import com.team3.otboo.event.FeedLikedEvent;
 import com.team3.otboo.global.exception.user.UserNotFoundException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class LikeService {
 
 	private final LikeRepository likeRepository;
@@ -69,6 +71,7 @@ public class LikeService {
 				.updatedAt(savedLike.getUpdatedAt())
 				.feedId(savedLike.getFeedId())
 				.userId(savedLike.getUserId())
+				.likeCount(count(feedId))
 				.build()
 		);
 
@@ -92,10 +95,12 @@ public class LikeService {
 						.updatedAt(feedLike.getUpdatedAt())
 						.feedId(feedLike.getFeedId())
 						.userId(feedLike.getUserId())
-						.likeCount(count(feedLike.getFeedId()))
+						.likeCount(count(feedId))
 						.build()
 				);
 			});
+
+		log.info("[LikeService.unlike] count(feedLike.getFeedId(): " + count(feedId));
 	}
 
 	@Transactional

--- a/src/main/java/com/team3/otboo/domain/feedread/document/FeedDocument.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/document/FeedDocument.java
@@ -1,0 +1,54 @@
+package com.team3.otboo.domain.feedread.document;
+
+import com.team3.otboo.domain.weather.enums.PrecipitationType;
+import com.team3.otboo.domain.weather.enums.SkyStatus;
+import jakarta.persistence.Id;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.InnerField;
+import org.springframework.data.elasticsearch.annotations.MultiField;
+
+@Getter
+@Setter
+@Document(indexName = "feeds")
+public class FeedDocument {
+
+	@Id
+	private UUID id; // feed_id
+
+	@Field(type = FieldType.Date)
+	private Instant createdAt;
+
+	@MultiField(
+		mainField = @Field(type = FieldType.Text, analyzer = "nori"),
+		otherFields = {
+			@InnerField(suffix = "raw", type = FieldType.Keyword, ignoreAbove = 256)
+		}
+	)
+	private String content;
+
+	@Field(type = FieldType.Keyword)
+	private UUID authorId;
+
+	@MultiField(
+		mainField = @Field(type = FieldType.Text, analyzer = "nori"),
+		otherFields = {
+			@InnerField(suffix = "raw", type = FieldType.Keyword, ignoreAbove = 256)
+		}
+	)
+	private String authorName;
+
+	@Field(type = FieldType.Keyword)
+	private SkyStatus skyStatus; // 날씨
+
+	@Field(type = FieldType.Keyword)
+	private PrecipitationType precipitationType; // 강수
+
+	@Field(type = FieldType.Integer)
+	private Integer likeCount;
+}

--- a/src/main/java/com/team3/otboo/domain/feedread/document/FeedDocument.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/document/FeedDocument.java
@@ -19,7 +19,10 @@ import org.springframework.data.elasticsearch.annotations.MultiField;
 public class FeedDocument {
 
 	@Id
-	private UUID id; // feed_id
+	private String id; // elasticsearch 내부용 ID 필드
+
+	@Field(type = FieldType.Keyword)
+	private UUID feedId;
 
 	@Field(type = FieldType.Date)
 	private Instant createdAt;
@@ -49,6 +52,6 @@ public class FeedDocument {
 	@Field(type = FieldType.Keyword)
 	private PrecipitationType precipitationType; // 강수
 
-	@Field(type = FieldType.Integer)
+	@Field(type = FieldType.Long)
 	private Integer likeCount;
 }

--- a/src/main/java/com/team3/otboo/domain/feedread/document/MongoFeedDocument.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/document/MongoFeedDocument.java
@@ -1,0 +1,37 @@
+package com.team3.otboo.domain.feedread.document;
+
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+
+@Getter
+@Setter
+//@Document(collection = "feeds_staging") // 데이터를 저장할 MongoDB 컬렉션 이름
+public class MongoFeedDocument {
+
+	@Id // MongoDB의 고유 ID 필드
+	private String id; // String 타입으로 사용하는 것이 일반적
+
+	private Instant createdAt;
+	private String content;
+	private UUID authorId;
+	private String authorName;
+	private String skyStatus;
+	private String precipitationType;
+	private Integer likeCount;
+
+	// elastic search document 를 MongoDB document 로 변환
+	public static MongoFeedDocument from(FeedDocument esDocument) {
+		MongoFeedDocument mongoDoc = new MongoFeedDocument();
+		mongoDoc.setId(esDocument.getId().toString());
+		mongoDoc.setCreatedAt(esDocument.getCreatedAt());
+		mongoDoc.setContent(esDocument.getContent());
+		mongoDoc.setAuthorId(esDocument.getAuthorId());
+		mongoDoc.setSkyStatus(esDocument.getSkyStatus().name());
+		mongoDoc.setPrecipitationType(esDocument.getPrecipitationType().name());
+		mongoDoc.setLikeCount(esDocument.getLikeCount());
+		return mongoDoc;
+	}
+}

--- a/src/main/java/com/team3/otboo/domain/feedread/document/MongoFeedDocument.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/document/MongoFeedDocument.java
@@ -12,7 +12,7 @@ import org.springframework.data.annotation.Id;
 public class MongoFeedDocument {
 
 	@Id // MongoDB의 고유 ID 필드
-	private String id; // String 타입으로 사용하는 것이 일반적
+	private String id;
 
 	private Instant createdAt;
 	private String content;

--- a/src/main/java/com/team3/otboo/domain/feedread/repository/FeedSearchRepository.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/repository/FeedSearchRepository.java
@@ -1,0 +1,9 @@
+package com.team3.otboo.domain.feedread.repository;
+
+import com.team3.otboo.domain.feedread.document.FeedDocument;
+import java.util.UUID;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface FeedSearchRepository extends ElasticsearchRepository<FeedDocument, UUID> {
+
+}

--- a/src/main/java/com/team3/otboo/domain/feedread/repository/MongoFeedDocumentRepository.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/repository/MongoFeedDocumentRepository.java
@@ -1,0 +1,5 @@
+package com.team3.otboo.domain.feedread.repository;
+
+public class MongoFeedDocumentRepository {
+
+}

--- a/src/main/java/com/team3/otboo/domain/feedread/repository/RedisLockManager.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/repository/RedisLockManager.java
@@ -1,0 +1,55 @@
+package com.team3.otboo.domain.feedread.repository;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisLockManager {
+
+	private final StringRedisTemplate redisTemplate;
+
+	/**
+	 * 락을 획득합니다.
+	 *
+	 * @param key     락 키
+	 * @param value   락 소유자를 식별하기 위한 값 (e.g., UUID)
+	 * @param timeout 락 만료 시간
+	 * @return 락 획득 성공 시 true, 실패 시 false
+	 */
+	public boolean acquireLock(String key, String value, Duration timeout) {
+		// SET key value NX EX timeout
+		Boolean success = redisTemplate.opsForValue()
+			.setIfAbsent(key, value, timeout);
+		return success != null && success;
+	}
+
+	/**
+	 * 락이 존재하는지 확인합니다.
+	 *
+	 * @param key 락 키
+	 * @return 락이 존재하면 true, 아니면 false
+	 */
+	public boolean isLockHeld(String key) {
+		return redisTemplate.hasKey(key);
+	}
+
+	/**
+	 * 락을 해제합니다.
+	 *
+	 * @param key   락 키
+	 * @param value 락을 획득할 때 사용했던 값
+	 * @return 락 해제 성공 시 true, 실패 시 false
+	 */
+	public boolean releaseLock(String key, String value) {
+		// 현재 락을 소유한 클라이언트인지 확인
+		String currentValue = redisTemplate.opsForValue().get(key);
+		if (value.equals(currentValue)) {
+			redisTemplate.delete(key);
+			return true;
+		}
+		return false;
+	}
+}

--- a/src/main/java/com/team3/otboo/domain/feedread/service/FeedIndexBatchService.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/service/FeedIndexBatchService.java
@@ -149,12 +149,12 @@ public class FeedIndexBatchService {
 	private IndexQuery buildIndexQuery(Feed feed, Map<UUID, Weather> weatherMap,
 		Map<UUID, FeedLikeCount> likeCountMap, Map<UUID, User> userMap) {
 		FeedDocument document = new FeedDocument();
-		document.setId(feed.getId());
+		document.setId(feed.getId().toString());
+		document.setFeedId(feed.getId());
 		document.setCreatedAt(feed.getCreatedAt());
 		document.setContent(feed.getContent());
 		document.setAuthorId(feed.getAuthorId());
 
-		// userMap에서 사용자 이름을 찾아 Document에 설정
 		User author = userMap.get(feed.getAuthorId());
 		if (author != null) {
 			document.setAuthorName(author.getUsername()); // User 엔티티의 이름 필드(getUsername)를 사용

--- a/src/main/java/com/team3/otboo/domain/feedread/service/FeedIndexBatchService.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/service/FeedIndexBatchService.java
@@ -1,0 +1,179 @@
+package com.team3.otboo.domain.feedread.service;
+
+import com.team3.otboo.domain.feed.entity.Feed;
+import com.team3.otboo.domain.feed.entity.FeedLikeCount;
+import com.team3.otboo.domain.feed.repository.FeedLikeCountRepository;
+import com.team3.otboo.domain.feed.repository.FeedRepository;
+import com.team3.otboo.domain.feedread.document.FeedDocument;
+import com.team3.otboo.domain.user.entity.User;
+import com.team3.otboo.domain.user.repository.UserRepository;
+import com.team3.otboo.domain.weather.entity.Weather;
+import com.team3.otboo.domain.weather.repository.WeatherRepository;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.IndexOperations;
+import org.springframework.data.elasticsearch.core.index.AliasAction;
+import org.springframework.data.elasticsearch.core.index.AliasActionParameters;
+import org.springframework.data.elasticsearch.core.index.AliasActions;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.query.IndexQuery;
+import org.springframework.data.elasticsearch.core.query.IndexQueryBuilder;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FeedIndexBatchService {
+
+	private static final int CHUNK_SIZE = 1000; // 한 번에 처리할 데이터 양
+	private static final String FEED_ALIAS = "feeds"; // 애플리케이션이 사용할 고정 별칭
+
+	private final FeedRepository feedRepository;
+	private final WeatherRepository weatherRepository;
+	private final FeedLikeCountRepository feedLikeCountRepository;
+	private final ElasticsearchOperations elasticsearchOperations;
+	private final UserRepository userRepository; // 사용자 정보 조회를 위해 UserRepository 추가
+
+	/**
+	 * 매일 새벽 1시에 실행되는 전체 색인 스케줄러 (Alias를 활용한 무중단 방식).
+	 */
+	@Scheduled(cron = "0 0 1 * * *")
+	@Transactional(readOnly = true)
+	public void runFullIndexingWithAlias() {
+		log.info(">>>>> [BATCH] 무중단 전체 색인 작업을 시작합니다.");
+
+		String newIndexName = FEED_ALIAS + "_" + LocalDateTime.now()
+			.format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
+		IndexCoordinates newIndexCoordinates = IndexCoordinates.of(newIndexName);
+
+		IndexOperations indexOperations = elasticsearchOperations.indexOps(newIndexCoordinates);
+		indexOperations.create();
+		indexOperations.putMapping(FeedDocument.class);
+		log.info(">>>>> [BATCH] 새로운 인덱스 '{}'를 생성했습니다.", newIndexName);
+
+		Pageable pageable = PageRequest.of(0, CHUNK_SIZE);
+		long totalFeedsProcessed = 0;
+
+		while (true) {
+			Page<Feed> feedPage = feedRepository.findAll(pageable);
+			List<Feed> feeds = feedPage.getContent();
+			if (feeds.isEmpty()) {
+				break;
+			}
+
+			processChunk(feeds, newIndexCoordinates);
+
+			totalFeedsProcessed += feeds.size();
+			log.info(">>>>> [BATCH] {}개의 피드를 '{}' 인덱스에 색인 완료. (총 {}개 처리)", feeds.size(),
+				newIndexName, totalFeedsProcessed);
+
+			if (!feedPage.hasNext()) {
+				break;
+			}
+			pageable = feedPage.nextPageable();
+		}
+
+		AliasActions aliasActions = new AliasActions();
+
+		Set<String> oldIndexNames = elasticsearchOperations.indexOps(
+			IndexCoordinates.of(FEED_ALIAS)).getAliasesForIndex("*").keySet();
+		oldIndexNames.forEach(oldIndex -> {
+			AliasActionParameters removeParams = AliasActionParameters.builder()
+				.withAliases(FEED_ALIAS)
+				.withIndices(oldIndex)
+				.build();
+			aliasActions.add(new AliasAction.Remove(removeParams));
+		});
+
+		AliasActionParameters addParams = AliasActionParameters.builder()
+			.withAliases(FEED_ALIAS)
+			.withIndices(newIndexName)
+			.build();
+		aliasActions.add(new AliasAction.Add(addParams));
+
+		if (!aliasActions.getActions().isEmpty()) {
+			elasticsearchOperations.indexOps(newIndexCoordinates).alias(aliasActions);
+		}
+		log.info(">>>>> [BATCH] 별칭 '{}'가 새로운 인덱스 '{}'를 가리키도록 교체했습니다.", FEED_ALIAS, newIndexName);
+
+		oldIndexNames.forEach(oldIndex -> {
+			elasticsearchOperations.indexOps(IndexCoordinates.of(oldIndex)).delete();
+			log.info(">>>>> [BATCH] 옛날 인덱스 '{}'를 삭제했습니다.", oldIndex);
+		});
+
+		log.info(">>>>> [BATCH] 총 {}개의 피드 전체 색인 완료. 작업을 종료합니다.", totalFeedsProcessed);
+	}
+
+	private void processChunk(List<Feed> feeds, IndexCoordinates indexCoordinates) {
+		List<UUID> feedIds = feeds.stream().map(Feed::getId).collect(Collectors.toList());
+		List<UUID> weatherIds = feeds.stream().map(Feed::getWeatherId).collect(Collectors.toList());
+		List<UUID> authorIds = feeds.stream().map(Feed::getAuthorId)
+			.collect(Collectors.toList()); // 작성자 ID 목록 추출
+
+		Map<UUID, Weather> weatherMap = weatherRepository.findAllByIdIn(weatherIds).stream()
+			.collect(Collectors.toMap(Weather::getId, Function.identity()));
+
+		Map<UUID, FeedLikeCount> likeCountMap = feedLikeCountRepository.findAllByIdIn(feedIds)
+			.stream()
+			.collect(Collectors.toMap(FeedLikeCount::getFeedId, Function.identity()));
+
+		// 작성자 ID 목록으로 사용자 정보 조회
+		Map<UUID, User> userMap = userRepository.findAllByIdIn(authorIds).stream()
+			.collect(Collectors.toMap(User::getId, Function.identity()));
+
+		// buildIndexQuery 호출 시 userMap 전달
+		List<IndexQuery> indexQueries = feeds.stream()
+			.map(feed -> buildIndexQuery(feed, weatherMap, likeCountMap, userMap))
+			.collect(Collectors.toList());
+
+		if (!indexQueries.isEmpty()) {
+			elasticsearchOperations.bulkIndex(indexQueries, indexCoordinates);
+		}
+	}
+
+	// buildIndexQuery 메소드에 userMap 파라미터 추가 및 로직 수정
+	private IndexQuery buildIndexQuery(Feed feed, Map<UUID, Weather> weatherMap,
+		Map<UUID, FeedLikeCount> likeCountMap, Map<UUID, User> userMap) {
+		FeedDocument document = new FeedDocument();
+		document.setId(feed.getId());
+		document.setCreatedAt(feed.getCreatedAt());
+		document.setContent(feed.getContent());
+		document.setAuthorId(feed.getAuthorId());
+
+		// userMap에서 사용자 이름을 찾아 Document에 설정
+		User author = userMap.get(feed.getAuthorId());
+		if (author != null) {
+			document.setAuthorName(author.getUsername()); // User 엔티티의 이름 필드(getUsername)를 사용
+		}
+
+		Weather weather = weatherMap.get(feed.getWeatherId());
+		if (weather != null) {
+			document.setSkyStatus(weather.getSkyStatus());
+			document.setPrecipitationType(weather.getPrecipitation().getType());
+		}
+
+		int likeCount = likeCountMap.containsKey(feed.getId())
+			? likeCountMap.get(feed.getId()).getLikeCount().intValue()
+			: 0;
+		document.setLikeCount(likeCount);
+
+		return new IndexQueryBuilder()
+			.withId(document.getId().toString())
+			.withObject(document)
+			.build();
+	}
+}

--- a/src/main/java/com/team3/otboo/domain/feedread/service/FeedReadService.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/service/FeedReadService.java
@@ -259,13 +259,21 @@ public class FeedReadService {
 		String sortByField = request.sortBy() != null ? request.sortBy() : "createdAt";
 		List<SortOptions> sorts = List.of(
 			SortOptions.of(s -> s.field(
-				f -> f.field(sortByField).order(desc ? SortOrder.Desc : SortOrder.Asc)
-			))
+				f -> f.field(sortByField).order(desc ? SortOrder.Desc : SortOrder.Asc))),
+			SortOptions.of(s -> s.field(f -> f.field("feedId").order(SortOrder.Asc)))
 		);
 
 		List<Object> searchAfter = null;
-		if (request.cursor() != null && !request.cursor().isBlank()) {
-			searchAfter = List.of(request.cursor());
+		if (request.cursor() != null && !request.cursor().isBlank() && request.idAfter() != null) {
+			Object primaryCursorValue = request.cursor();
+			if ("likeCount".equals(sortByField)) {
+				try {
+					primaryCursorValue = Integer.parseInt(request.cursor());
+				} catch (NumberFormatException e) {
+					log.warn("Invalid cursor value for likeCount: {}", request.cursor());
+				}
+			}
+			searchAfter = List.of(primaryCursorValue, request.idAfter().toString());
 		}
 
 		NativeQueryBuilder queryBuilder = new NativeQueryBuilder()
@@ -290,7 +298,7 @@ public class FeedReadService {
 			hasNext ? searchHits.subList(0, request.limit()) : searchHits;
 
 		List<UUID> pageIds = pageHits.stream()
-			.map(hit -> hit.getContent().getId())
+			.map(hit -> hit.getContent().getFeedId())
 			.toList();
 
 		List<FeedDto> data;
@@ -314,8 +322,9 @@ public class FeedReadService {
 		if (hasNext) {
 			var lastHit = pageHits.getLast();
 			List<Object> sortValues = lastHit.getSortValues();
-			if (!sortValues.isEmpty()) {
+			if (sortValues.size() >= 2) {
 				nextCursor = sortValues.get(0).toString();
+				nextIdAfter = UUID.fromString(sortValues.get(1).toString());
 			}
 		}
 

--- a/src/main/java/com/team3/otboo/domain/feedread/service/event/handler/FeedCreatedEventHandler.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/service/event/handler/FeedCreatedEventHandler.java
@@ -5,9 +5,11 @@ import com.team3.otboo.common.event.EventType;
 import com.team3.otboo.common.event.payload.FeedCreatedEventPayload;
 import com.team3.otboo.domain.feed.dto.FeedDto;
 import com.team3.otboo.domain.feed.mapper.FeedDtoAssembler;
+import com.team3.otboo.domain.feedread.document.FeedDocument;
 import com.team3.otboo.domain.feedread.repository.FeedIdListRepository;
 import com.team3.otboo.domain.feedread.repository.FeedQueryModel;
 import com.team3.otboo.domain.feedread.repository.FeedQueryModelRepository;
+import com.team3.otboo.domain.feedread.repository.FeedSearchRepository;
 import java.time.Duration;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +23,7 @@ public class FeedCreatedEventHandler implements EventHandler<FeedCreatedEventPay
 	private final FeedIdListRepository feedIdListRepository;
 
 	private final FeedDtoAssembler feedDtoAssembler;
+	private final FeedSearchRepository feedSearchRepository;
 
 	@Override
 	public void handle(Event<FeedCreatedEventPayload> event) {
@@ -33,6 +36,17 @@ public class FeedCreatedEventHandler implements EventHandler<FeedCreatedEventPay
 			Duration.ofDays(1)
 		);
 		feedIdListRepository.add(feedId, payload.getCreatedAt(), 1000L); // id list 는 1000개 까지 저장 .
+
+		FeedDocument feedDocument = new FeedDocument();
+		feedDocument.setId(payload.getId());
+		feedDocument.setCreatedAt(payload.getCreatedAt());
+		feedDocument.setContent(payload.getContent());
+		feedDocument.setAuthorId(payload.getAuthorId());
+		feedDocument.setAuthorName(feedDto.author().name());
+		feedDocument.setSkyStatus(payload.getSkyStatus());
+		feedDocument.setPrecipitationType(payload.getPrecipitationType());
+		feedDocument.setLikeCount(0); // 생성시 like count 는 0
+		feedSearchRepository.save(feedDocument);
 	}
 
 	@Override

--- a/src/main/java/com/team3/otboo/domain/feedread/service/event/handler/FeedCreatedEventHandler.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/service/event/handler/FeedCreatedEventHandler.java
@@ -38,7 +38,8 @@ public class FeedCreatedEventHandler implements EventHandler<FeedCreatedEventPay
 		feedIdListRepository.add(feedId, payload.getCreatedAt(), 1000L); // id list 는 1000개 까지 저장 .
 
 		FeedDocument feedDocument = new FeedDocument();
-		feedDocument.setId(payload.getId());
+		feedDocument.setId(payload.getId().toString());
+		feedDocument.setFeedId(payload.getId());
 		feedDocument.setCreatedAt(payload.getCreatedAt());
 		feedDocument.setContent(payload.getContent());
 		feedDocument.setAuthorId(payload.getAuthorId());

--- a/src/main/java/com/team3/otboo/domain/feedread/service/event/handler/FeedDeletedEventHandler.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/service/event/handler/FeedDeletedEventHandler.java
@@ -5,6 +5,7 @@ import com.team3.otboo.common.event.EventType;
 import com.team3.otboo.common.event.payload.FeedDeletedEventPayload;
 import com.team3.otboo.domain.feedread.repository.FeedIdListRepository;
 import com.team3.otboo.domain.feedread.repository.FeedQueryModelRepository;
+import com.team3.otboo.domain.feedread.repository.FeedSearchRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -15,11 +16,15 @@ public class FeedDeletedEventHandler implements EventHandler<FeedDeletedEventPay
 	private final FeedQueryModelRepository feedQueryModelRepository;
 	private final FeedIdListRepository feedIdListRepository;
 
+	private final FeedSearchRepository feedSearchRepository;
+
 	@Override
 	public void handle(Event<FeedDeletedEventPayload> event) {
 		FeedDeletedEventPayload payload = event.getPayload();
 		feedQueryModelRepository.delete(payload.getId());
 		feedIdListRepository.delete(payload.getId());
+
+		feedSearchRepository.deleteById(payload.getId());
 	}
 
 	@Override

--- a/src/main/java/com/team3/otboo/domain/feedread/service/event/handler/FeedLikedEventHandler.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/service/event/handler/FeedLikedEventHandler.java
@@ -4,14 +4,23 @@ import com.team3.otboo.common.event.Event;
 import com.team3.otboo.common.event.EventType;
 import com.team3.otboo.common.event.payload.FeedLikedEventPayload;
 import com.team3.otboo.domain.feedread.repository.FeedQueryModelRepository;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.document.Document;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.query.UpdateQuery;
 import org.springframework.stereotype.Component;
 
 @Component("feedReadFeedLikedEventHandler")
 @RequiredArgsConstructor
+@Slf4j
 public class FeedLikedEventHandler implements EventHandler<FeedLikedEventPayload> {
 
 	private final FeedQueryModelRepository feedQueryModelRepository;
+
+	private final ElasticsearchOperations elasticsearchOperations;
 
 	@Override
 	public void handle(Event<FeedLikedEventPayload> event) {
@@ -21,6 +30,16 @@ public class FeedLikedEventHandler implements EventHandler<FeedLikedEventPayload
 			.ifPresent(feedQueryModel -> {
 				feedQueryModel.updateBy(payload);
 				feedQueryModelRepository.update(feedQueryModel);
+
+				Long likeCount = payload.getLikeCount();
+
+				Map<String, Object> patch = Map.of("likeCount", likeCount);
+				log.info("[FeedLikedEventHandler.handle] likeCount: {}", likeCount);
+				UpdateQuery updateQuery = UpdateQuery.builder(feedQueryModel.getId().toString())
+					.withDocument(Document.from(patch))
+					.build();
+
+				elasticsearchOperations.update(updateQuery, IndexCoordinates.of("feeds"));
 			});
 	}
 

--- a/src/main/java/com/team3/otboo/domain/feedread/service/event/handler/FeedUnlikedEventHandler.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/service/event/handler/FeedUnlikedEventHandler.java
@@ -4,14 +4,23 @@ import com.team3.otboo.common.event.Event;
 import com.team3.otboo.common.event.EventType;
 import com.team3.otboo.common.event.payload.FeedUnlikedEventPayload;
 import com.team3.otboo.domain.feedread.repository.FeedQueryModelRepository;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.document.Document;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.query.UpdateQuery;
 import org.springframework.stereotype.Component;
 
 @Component("feedReadFeedUnlikedEventHandler")
 @RequiredArgsConstructor
+@Slf4j
 public class FeedUnlikedEventHandler implements EventHandler<FeedUnlikedEventPayload> {
 
 	private final FeedQueryModelRepository feedQueryModelRepository;
+
+	private final ElasticsearchOperations elasticsearchOperations;
 
 	@Override
 	public void handle(Event<FeedUnlikedEventPayload> event) {
@@ -20,6 +29,16 @@ public class FeedUnlikedEventHandler implements EventHandler<FeedUnlikedEventPay
 			.ifPresent(feedQueryModel -> {
 				feedQueryModel.updateBy(payload);
 				feedQueryModelRepository.update(feedQueryModel);
+
+				Long likeCount = payload.getLikeCount();
+				log.info("[FeedUnlikedEventHandler.handle] likeCount: {}", likeCount);
+
+				Map<String, Object> patch = Map.of("likeCount", likeCount);
+				UpdateQuery updateQuery = UpdateQuery.builder(feedQueryModel.getId().toString())
+					.withDocument(Document.from(patch))
+					.build();
+
+				elasticsearchOperations.update(updateQuery, IndexCoordinates.of("feeds"));
 			});
 	}
 

--- a/src/main/java/com/team3/otboo/domain/feedread/service/event/handler/FeedUpdatedEventHandler.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/service/event/handler/FeedUpdatedEventHandler.java
@@ -3,8 +3,15 @@ package com.team3.otboo.domain.feedread.service.event.handler;
 import com.team3.otboo.common.event.Event;
 import com.team3.otboo.common.event.EventType;
 import com.team3.otboo.common.event.payload.FeedUpdatedEventPayload;
+import com.team3.otboo.domain.feedread.document.FeedDocument;
 import com.team3.otboo.domain.feedread.repository.FeedQueryModelRepository;
+import com.team3.otboo.domain.feedread.repository.FeedSearchRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.query.UpdateQuery;
 import org.springframework.stereotype.Component;
 
 @Component("feedReadFeedUpdatedEventHandler")
@@ -13,6 +20,9 @@ public class FeedUpdatedEventHandler implements EventHandler<FeedUpdatedEventPay
 
 	private final FeedQueryModelRepository feedQueryModelRepository;
 
+	private final FeedSearchRepository feedSearchRepository;
+	private final ElasticsearchOperations elasticsearchOperations;
+
 	@Override
 	public void handle(Event<FeedUpdatedEventPayload> event) {
 		FeedUpdatedEventPayload payload = event.getPayload();
@@ -20,7 +30,20 @@ public class FeedUpdatedEventHandler implements EventHandler<FeedUpdatedEventPay
 			.ifPresent(feedQueryModel -> {
 				feedQueryModel.updateBy(payload);
 				feedQueryModelRepository.update(feedQueryModel);
+
 			});
+
+		FeedDocument feedDocument = feedSearchRepository.findById(payload.getId()).orElseThrow(() ->
+			new EntityNotFoundException(
+				"[FeedUpdatedEventHandler.handle] feed document not found. feed id: "
+					+ payload.getId())
+		);
+
+		Map<String, Object> patch = Map.of("content", payload.getContent());
+		UpdateQuery uq = UpdateQuery.builder(payload.getId().toString())
+			.withDocument(org.springframework.data.elasticsearch.core.document.Document.from(patch))
+			.build();
+		elasticsearchOperations.update(uq, IndexCoordinates.of("feeds"));
 	}
 
 	@Override

--- a/src/main/java/com/team3/otboo/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/team3/otboo/domain/user/repository/UserRepository.java
@@ -1,9 +1,12 @@
 package com.team3.otboo.domain.user.repository;
 
 import com.team3.otboo.domain.user.entity.User;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -16,4 +19,16 @@ public interface UserRepository extends JpaRepository<User, UUID>, UserRepositor
 	Optional<User> findByUsername(String username);
 
 	Optional<User> findByEmail(String email);
+
+	/**
+	 * 주어진 ID 목록에 해당하는 모든 사용자를 조회합니다.
+	 *
+	 * @param ids 조회할 사용자 ID 목록
+	 * @return 조회된 사용자 엔티티 목록
+	 */
+	@Query(
+		value = "SELECT * FROM users WHERE id IN (:ids)",
+		nativeQuery = true)
+	List<User> findAllByIdIn(@Param("ids") List<UUID> ids);
+
 }

--- a/src/main/java/com/team3/otboo/domain/weather/repository/WeatherRepository.java
+++ b/src/main/java/com/team3/otboo/domain/weather/repository/WeatherRepository.java
@@ -1,7 +1,6 @@
 package com.team3.otboo.domain.weather.repository;
 
 import com.team3.otboo.domain.weather.entity.Weather;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -14,36 +13,44 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface WeatherRepository extends JpaRepository<Weather, UUID> {
-    @Query("""
-      SELECT w 
-      FROM Weather w 
-      WHERE w.location.x  = :x
-        AND w.location.y = :y
-        AND FUNCTION('date', w.forecastAt) = :forecastDate
-      ORDER BY w.forecastAt DESC
-    """)
-    Optional<Weather> findxByyAndForecastDate(
-            @Param("x")     double x,
-            @Param("y")    double y,
-            @Param("forecastDate") LocalDate forecastDate
-    );
 
-    Optional<Weather> findByLocation_XAndLocation_YAndForecastAt(Integer x, Integer y, LocalDateTime forecastAt);
+	@Query("""
+		  SELECT w 
+		  FROM Weather w 
+		  WHERE w.location.x  = :x
+		    AND w.location.y = :y
+		    AND FUNCTION('date', w.forecastAt) = :forecastDate
+		  ORDER BY w.forecastAt DESC
+		""")
+	Optional<Weather> findxByyAndForecastDate(
+		@Param("x") double x,
+		@Param("y") double y,
+		@Param("forecastDate") LocalDate forecastDate
+	);
 
-    @Query("""
-    SELECT w
-    FROM Weather w
-    WHERE w.location.x = :x
-      AND w.location.y = :y
-      AND w.forecastedAt = :forecastedAt
-      AND w.forecastAt >= :fromForecastAt
-      AND w.forecastAt < :toForecastAt
-    """)
-    List<Weather> findWeathersWithForecastedAt(
-            @Param("x") Integer x,
-            @Param("y") Integer y,
-            @Param("forecastedAt") LocalDateTime forecastedAt,
-            @Param("fromForecastAt") LocalDateTime fromForecastAt,
-            @Param("toForecastAt") LocalDateTime toForecastAt
-    );
+	Optional<Weather> findByLocation_XAndLocation_YAndForecastAt(Integer x, Integer y,
+		LocalDateTime forecastAt);
+
+	@Query("""
+		SELECT w
+		FROM Weather w
+		WHERE w.location.x = :x
+		  AND w.location.y = :y
+		  AND w.forecastedAt = :forecastedAt
+		  AND w.forecastAt >= :fromForecastAt
+		  AND w.forecastAt < :toForecastAt
+		""")
+	List<Weather> findWeathersWithForecastedAt(
+		@Param("x") Integer x,
+		@Param("y") Integer y,
+		@Param("forecastedAt") LocalDateTime forecastedAt,
+		@Param("fromForecastAt") LocalDateTime fromForecastAt,
+		@Param("toForecastAt") LocalDateTime toForecastAt
+	);
+
+	@Query(
+		value = "SELECT * FROM weather w WHERE w.id IN (:ids)",
+		nativeQuery = true
+	)
+	List<Weather> findAllByIdIn(@Param("ids") List<UUID> ids);
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,3 +10,5 @@ logging:
     org.hibernate.SQL: info
     org.hibernate.orm.jdbc.bind: info
     org.apache.kafka: WARN
+    org.springframework.data.elasticsearch.client: TRACE
+    org.elasticsearch.client: TRACE

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -75,6 +75,10 @@ spring:
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       enable-auto-commit: false
 
+  elasticsearch:
+    uris:
+      - http://15.164.170.61:9200
+
 server:
   port: 8080
 


### PR DESCRIPTION
## 개요
처음에 Redis를 조회용 DB로 선정하였으나, 검색 조건이 있는 경우 처리가 매우 어려웠습니다.
그래서 어쩔 수 없이 검색 조건이 있는 경우 Command 쪽의 RDBMS에게 요청을 하고 있었습니다.

수정 전 피드 목록 조회 요청이 들어왔을때 요청의 흐름도
<img width="861" height="287" alt="image" src="https://github.com/user-attachments/assets/582c41a7-7644-42e7-a84d-a0306ae8a4af" />

이건 CQRS 가 아니라 그냥 캐싱과 다를게 없어 검색 쿼리는 elastic search 를 사용하여 처리하도록 변경하였습니다.

수정 후 피드 목록 조회 요청이 들어왔을때 요청의 흐름도
<img width="865" height="406" alt="image" src="https://github.com/user-attachments/assets/4adf2e51-ca1a-4381-a908-4395816e39dd" />

## elastic search의 부분색인과 전체색인
<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/faf318b3-6b44-4487-818c-7c68ba4af272" />

elastic search 의 색인 작업을 두가지로 나누어 진행을 했습니다. 전체색인과 부분색인 입니다.

전체 색인은 하루에 한번씩, DB에 저장된 모든 피드 데이터를 재색인하는 작업입니다.

부분 색인은 실시간으로 생성, 수정, 삭제된 피드 데이터들을 elastic에 search 색인해주는 작업입니다.
저희가 색인 작업을 두가지로 나눈 이유는 데이터 정합성의 문제 때문에 전체색인과 부분색인으로 나누게 되었습니다. 이 두가지 작업은 동시에 일어나면 데이터 정합성이 안맞는 문제가 생기므로, 하나의 작업만 진행되도록 만들어야합니다.

### 전체 색인 아키텍처
**전체 색인**은 메인 데이터베이스(PostgreSQL)에 저장된 모든 데이터를 Elasticsearch로 재색인하는 작업입니다. 이 작업은 매일 새벽 1시에 Spring Batch를 통해 실행되며, 혹시 모를 데이터 불일치를 바로잡고 전체 데이터의 정합성을 보장하는 역할을 합니다. 전체 색인을 진행할때는 항상 lock 을 획득하여, 부분 색인과 동시에 동작하지 않도록 해야합니다.

(전체 색인 작업을 할때는 무중단 색인을 위해 인덱스 별칭인 Alias를 활용)
<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/62c81b63-d8e7-4df2-9f66-60a888cf80aa" />


### 부분 색인 아키텍처

**부분 색인**은 Feed 데이터가 변경되는 즉시, 이를 Elasticsearch에 실시간으로 반영하는 작업입니다. 저희는 이 과정을 **Kafka를 이용한 이벤트 기반 아키텍처**로 구현했습니다. (이미 인기피드 기능, 피드 조회 서비스를 위해 Kafka 아키텍처가 구현 되어 있었기 때문에, 이를 활용하였습니다.)

과정을 간단하게 설명드리면, 먼저 Consumer는 Feed에 대한 이벤트(create, update, delete)를 실시간으로 전달 받고, 임시 저장소인 Mongo DB에 1차적으로 저장합니다. 그 후 redis lock을 통해 전체 색인 작업이 진행 중인지 확인하고, 전체 색인이 진행중이지 않다면 elastic search에 최신화된 데이터를 색인합니다.

왜 바로 elasticsearch에 데이터를 밀어넣지 않고, mongoDB에 저장하는지가 궁금하실텐데,  가장 큰 이유는 역시 정합성입니다.  Elasticsearch 서버가 다운되거나, 네트워크 장애가 발생할 수 있다는 가정하에, 색인의 실패에 대비하기 위해 MongoDB에 1차적으로 데이터를 저장하였습니다.

(MongoDB에 저장하는 것도 실패했으면 어떻게 하나요 ? → 매우 낮은 확률로 둘다 실패할 경우가 생길 수는 있으나, 전체 색인을 통해 매일 새벽 1시에 전체 데이터를 다시 재색인 하고 있기 때문에 DB와 의 데이터 정합성이 맞춰지게 됩니다.)
<img width="870" height="261" alt="image" src="https://github.com/user-attachments/assets/0052e207-6c0e-4ab2-bb7f-7fde1397ed2a" />

### Redis를 활용한 락 관리

색인 작업의 상태를 관리하고 작업 간 충돌을 방지하기 위해 Redis를 사용하였습니다.

색인 작업 시작시, Lock을 점유하여 전체 색인과 부분색인이 동시에 일어나지 못하게 설계하였습니다.

참고 자료:

https://www.youtube.com/watch?v=fBfUr_8Pq8A&t=437s
