### PR TITLE
feat: 조회수 서비스 구현

### DIFF
--- a/Dockerfile.elastic
+++ b/Dockerfile.elastic
@@ -1,0 +1,2 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.17.4
+RUN bin/elasticsearch-plugin install analysis-nori

--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     implementation 'org.jetbrains:annotations:24.0.1'
+
+    // Elastic Search
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+
+    // MongoDB
+//    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/team3/otboo/common/event/EventType.java
+++ b/src/main/java/com/team3/otboo/common/event/EventType.java
@@ -23,7 +23,6 @@ public enum EventType {
 	FEED_LIKED(FeedLikedEventPayload.class, Topic.OTBOO_FEED_LIKE),
 	FEED_UNLIKED(FeedUnlikedEventPayload.class, Topic.OTBOO_FEED_LIKE),
 	DIRECT_MESSAGE_SENT(DirectMessageSentPayload.class, Topic.OTBOO_DIRECT_MESSAGE),
-	// 나중에 view service 만들기 .
 	FEED_VIEWED(FeedViewedEventPayload.class, Topic.OTBOO_FEED_VIEW);
 
 	private final Class<? extends EventPayload> payloadClass;

--- a/src/main/java/com/team3/otboo/common/event/payload/FeedCreatedEventPayload.java
+++ b/src/main/java/com/team3/otboo/common/event/payload/FeedCreatedEventPayload.java
@@ -1,6 +1,8 @@
 package com.team3.otboo.common.event.payload;
 
 import com.team3.otboo.common.event.EventPayload;
+import com.team3.otboo.domain.weather.enums.PrecipitationType;
+import com.team3.otboo.domain.weather.enums.SkyStatus;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -20,4 +22,7 @@ public class FeedCreatedEventPayload implements EventPayload {
 	private UUID authorId;
 	private UUID weatherId;
 	private String content;
+
+	private SkyStatus skyStatus;
+	private PrecipitationType precipitationType;
 }

--- a/src/main/java/com/team3/otboo/config/ElasticSearchConfig.java
+++ b/src/main/java/com/team3/otboo/config/ElasticSearchConfig.java
@@ -1,0 +1,10 @@
+package com.team3.otboo.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+@Configuration
+@EnableElasticsearchRepositories(basePackages = "com.team3.otboo.domain.feedread.repository")
+public class ElasticSearchConfig {
+
+}

--- a/src/main/java/com/team3/otboo/config/RedisConfig.java
+++ b/src/main/java/com/team3/otboo/config/RedisConfig.java
@@ -37,7 +37,6 @@ public class RedisConfig {
 		return new LettuceConnectionFactory(configuration);
 	}
 
-	// publish 객체 .
 	@Bean
 	@Qualifier("chatPubSub")
 	public RedisTemplate<String, Object> redisTemplate(
@@ -82,7 +81,7 @@ public class RedisConfig {
 	@Bean
 	@Primary
 	public RedisTemplate<String, Object> tokenRedisTemplate(
-			RedisConnectionFactory redisConnectionFactory){
+		RedisConnectionFactory redisConnectionFactory) {
 		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
 		redisTemplate.setConnectionFactory(redisConnectionFactory);
 

--- a/src/main/java/com/team3/otboo/config/SecurityConfig.java
+++ b/src/main/java/com/team3/otboo/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import com.team3.otboo.domain.user.jwt.login.JwtLoginSuccessHandler;
 import com.team3.otboo.domain.user.oauth.OAuth2LoginSuccessHandler;
 import com.team3.otboo.domain.user.user_details.CustomOAuthUserService;
 import java.util.Arrays;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -151,18 +152,12 @@ public class SecurityConfig {
 	@Bean
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration configuration = new CorsConfiguration();
-		// 프론트엔드 주소를 정확하게 명시해야 합니다.
-		configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173"));
-		// 필요한 HTTP 메서드를 허용합니다.
+		configuration.setAllowedOrigins(List.of("http://localhost:5173"));
 		configuration.setAllowedMethods(
 			Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-		// 모든 헤더를 허용합니다.
-		configuration.setAllowedHeaders(Arrays.asList("*"));
-		// ★★★ 이 설정이 쿠키 전송을 허용하는 핵심입니다.
+		configuration.setAllowedHeaders(List.of("*"));
 		configuration.setAllowCredentials(true);
-
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-		// 모든 경로("/**")에 위 설정을 적용합니다.
 		source.registerCorsConfiguration("/**", configuration);
 		return source;
 	}

--- a/src/main/java/com/team3/otboo/config/SecurityConfig.java
+++ b/src/main/java/com/team3/otboo/config/SecurityConfig.java
@@ -1,21 +1,27 @@
 package com.team3.otboo.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.team3.otboo.domain.user.jwt.login.*;
 import com.team3.otboo.domain.user.enums.Role;
-import com.team3.otboo.domain.user.jwt.*;
+import com.team3.otboo.domain.user.jwt.JwtAuthenticationFilter;
+import com.team3.otboo.domain.user.jwt.JwtLogoutHandler;
+import com.team3.otboo.domain.user.jwt.JwtService;
+import com.team3.otboo.domain.user.jwt.login.CustomAuthenticationProvider;
+import com.team3.otboo.domain.user.jwt.login.CustomLoginFailureHandler;
+import com.team3.otboo.domain.user.jwt.login.JsonUsernamePasswordAuthenticationFilter;
+import com.team3.otboo.domain.user.jwt.login.JwtLoginSuccessHandler;
 import com.team3.otboo.domain.user.oauth.OAuth2LoginSuccessHandler;
 import com.team3.otboo.domain.user.user_details.CustomOAuthUserService;
+import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchyAuthoritiesMapper;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -28,6 +34,9 @@ import org.springframework.security.web.authentication.logout.HttpStatusReturnin
 import org.springframework.security.web.authentication.session.NullAuthenticatedSessionStrategy;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Slf4j
 @Configuration
@@ -35,120 +44,142 @@ import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 @EnableMethodSecurity // (Secured, PreAuthorize) 보안 어노테이션 활성화
 public class SecurityConfig {
 
-    @Bean
-    public SecurityFilterChain securityFilterChain(
-            HttpSecurity http,
-            ObjectMapper objectMapper,
-            DaoAuthenticationProvider daoAuthenticationProvider,
-            CustomAuthenticationProvider customAuthenticationProvider,
-            JwtService jwtService,
-            CustomOAuthUserService customOAuthUserService,
-            OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler
-    ) throws Exception {
-        // 인증 -> AuthenticationProvider
-        // 인가 -> 일부 URL은 허용, 나머지는 ADMIN 권한 필요
-        // CSRF -> 기본 활성화, 로그아웃은 예외처리
-        // 로그아웃 -> 세션 삭제 + 200 응답
-        // 로그인 필터 -> 기본 필터 대신 JSON기반 필터 사용
-        // 세션 관리 -> 세션 고정 공격 방지 + 동시 로그인 제한
-        http
-                // Http Security에 직접 provider 등록
-                .authenticationProvider(daoAuthenticationProvider)
-                .authenticationProvider(customAuthenticationProvider);
-        // Http Security로부터 빌드된 manager를 가져와 사용하겠다는 말
-        AuthenticationManager authenticationManager = http.getSharedObject(AuthenticationManager.class);
+	@Bean
+	public SecurityFilterChain securityFilterChain(
+		HttpSecurity http,
+		ObjectMapper objectMapper,
+		DaoAuthenticationProvider daoAuthenticationProvider,
+		CustomAuthenticationProvider customAuthenticationProvider,
+		JwtService jwtService,
+		CustomOAuthUserService customOAuthUserService,
+		OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler
+	) throws Exception {
+		// 인증 -> AuthenticationProvider
+		// 인가 -> 일부 URL은 허용, 나머지는 ADMIN 권한 필요
+		// CSRF -> 기본 활성화, 로그아웃은 예외처리
+		// 로그아웃 -> 세션 삭제 + 200 응답
+		// 로그인 필터 -> 기본 필터 대신 JSON기반 필터 사용
+		// 세션 관리 -> 세션 고정 공격 방지 + 동시 로그인 제한
+		http
+			// Http Security에 직접 provider 등록
+			.authenticationProvider(daoAuthenticationProvider)
+			.authenticationProvider(customAuthenticationProvider);
+		// Http Security로부터 빌드된 manager를 가져와 사용하겠다는 말
+		AuthenticationManager authenticationManager = http.getSharedObject(
+			AuthenticationManager.class);
 
-        http
-                // 인가 정책 설정
-                .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers(HttpMethod.POST, "/api/users").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/auth/csrf-token").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/auth/refresh").permitAll()
-                        .requestMatchers("/api/auth/sign-in/**").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/auth/reset-password").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/auth/me").permitAll()
-                        .requestMatchers("/uploads/**").permitAll() // 로컬 이미지 찾기 위한 url 경로 허용
-                        .requestMatchers("/actuator/health", "/actuator/health/**").permitAll() // 헬스체크 허용
-                        .requestMatchers(HttpMethod.GET, "/api/clothes/extractions").permitAll() // 임시 허용.
-                        .requestMatchers("/api/**").authenticated()
-                        .requestMatchers("/", "/assets/**", "/*.html", "/*.css", "/*.js", "/favicon.ico", "/*.png", "/ws/**").permitAll()
-                        .anyRequest().authenticated()
-                )
-                .csrf(csrf ->
-                        csrf
-                                // 로그아웃 요청에 대해 CSRF 보호를 비활성화 -> 빠른 처리를 위해
-                                // 웹소켓의 원활한 통신을 위해 추가
-                                .ignoringRequestMatchers("/ws/**", "/api/auth/sign-out")
-                                // 서버에서 생성한 CSRF 토큰을 쿠키에 저장하여 사용자에게 전달, JS에서 접근할 수 있게 함
-                                // XSRF-TOKEN, X-XSRF-TOKEN 자동 지정해줌
-                                .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-                                // CSRF 토큰을 요청(request) 속성에서도 사용할 수 있도록 설정
-                                .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())
-                                // CSRF 보호 기능이 불필요하게 세션을 생성하는 것을 방지
-                                .sessionAuthenticationStrategy(new NullAuthenticatedSessionStrategy())
-                )
-                .with(
-                        new JsonUsernamePasswordAuthenticationFilter.Configurer(objectMapper),
-                        configurer ->
-                                configurer
-                                        .successHandler(new JwtLoginSuccessHandler(objectMapper, jwtService))
-                                        .failureHandler(new CustomLoginFailureHandler(objectMapper))
-                )
-                // OAuth 로그인을 시도할 때, custom한걸 사용하도록
-                .oauth2Login(oauth -> oauth
-                        .userInfoEndpoint(userInfo -> userInfo
-                                .userService(customOAuthUserService))
-                        .successHandler(oAuth2LoginSuccessHandler)
-                )
-                .logout(logout ->
-                        logout
-                                // logout URL 경로 지정
-                                .logoutUrl("/api/auth/sign-out")
-                                // 로그아웃 성공 시 리다이렉트 대신 HTTP 200 OK 상태 코드만 반환
-                                .logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler())
-                                // JWT 무효화하는 로직 수행
-                                .addLogoutHandler(new JwtLogoutHandler(jwtService))
-                )
-                .sessionManagement(session ->
-                        session
-                                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtService, objectMapper),
-                        JsonUsernamePasswordAuthenticationFilter.class);
-        return http.build();
-    }
+		http
+			// 인가 정책 설정
+			.cors(Customizer.withDefaults())
+			.authorizeHttpRequests(authorize -> authorize
+				.requestMatchers(HttpMethod.POST, "/api/users").permitAll()
+				.requestMatchers(HttpMethod.GET, "/api/auth/csrf-token").permitAll()
+				.requestMatchers(HttpMethod.POST, "/api/auth/refresh").permitAll()
+				.requestMatchers("/api/auth/sign-in/**").permitAll()
+				.requestMatchers(HttpMethod.POST, "/api/auth/reset-password").permitAll()
+				.requestMatchers(HttpMethod.GET, "/api/auth/me").permitAll()
+				.requestMatchers("/uploads/**").permitAll() // 로컬 이미지 찾기 위한 url 경로 허용
+				.requestMatchers("/actuator/health", "/actuator/health/**").permitAll() // 헬스체크 허용
+				.requestMatchers(HttpMethod.GET, "/api/clothes/extractions").permitAll() // 임시 허용.
+				.requestMatchers("/api/**").authenticated()
+				.requestMatchers("/", "/assets/**", "/*.html", "/*.css", "/*.js", "/favicon.ico",
+					"/*.png", "/ws/**").permitAll()
+				.anyRequest().authenticated()
+			)
+			.csrf(csrf ->
+				csrf
+					// 로그아웃 요청에 대해 CSRF 보호를 비활성화 -> 빠른 처리를 위해
+					// 웹소켓의 원활한 통신을 위해 추가
+					.ignoringRequestMatchers("/ws/**", "/api/auth/sign-out")
+					// 서버에서 생성한 CSRF 토큰을 쿠키에 저장하여 사용자에게 전달, JS에서 접근할 수 있게 함
+					// XSRF-TOKEN, X-XSRF-TOKEN 자동 지정해줌
+					.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+					// CSRF 토큰을 요청(request) 속성에서도 사용할 수 있도록 설정
+					.csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())
+					// CSRF 보호 기능이 불필요하게 세션을 생성하는 것을 방지
+					.sessionAuthenticationStrategy(new NullAuthenticatedSessionStrategy())
+			)
+			.with(
+				new JsonUsernamePasswordAuthenticationFilter.Configurer(objectMapper),
+				configurer ->
+					configurer
+						.successHandler(new JwtLoginSuccessHandler(objectMapper, jwtService))
+						.failureHandler(new CustomLoginFailureHandler(objectMapper))
+			)
+			// OAuth 로그인을 시도할 때, custom한걸 사용하도록
+			.oauth2Login(oauth -> oauth
+				.userInfoEndpoint(userInfo -> userInfo
+					.userService(customOAuthUserService))
+				.successHandler(oAuth2LoginSuccessHandler)
+			)
+			.logout(logout ->
+				logout
+					// logout URL 경로 지정
+					.logoutUrl("/api/auth/sign-out")
+					// 로그아웃 성공 시 리다이렉트 대신 HTTP 200 OK 상태 코드만 반환
+					.logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler())
+					// JWT 무효화하는 로직 수행
+					.addLogoutHandler(new JwtLogoutHandler(jwtService))
+			)
+			.sessionManagement(session ->
+				session
+					.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+			)
+			.addFilterBefore(new JwtAuthenticationFilter(jwtService, objectMapper),
+				JsonUsernamePasswordAuthenticationFilter.class);
+		return http.build();
+	}
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
 
-    @Bean
-    public DaoAuthenticationProvider daoAuthenticationProvider(
-            UserDetailsService userDetailsService,
-            PasswordEncoder passwordEncoder,
-            RoleHierarchy roleHierarchy
-    ) {
-        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
-        provider.setUserDetailsService(userDetailsService);
-        provider.setPasswordEncoder(passwordEncoder);
-        provider.setAuthoritiesMapper(new RoleHierarchyAuthoritiesMapper(roleHierarchy));
-        return provider;
-    }
+	@Bean
+	public DaoAuthenticationProvider daoAuthenticationProvider(
+		UserDetailsService userDetailsService,
+		PasswordEncoder passwordEncoder,
+		RoleHierarchy roleHierarchy
+	) {
+		DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+		provider.setUserDetailsService(userDetailsService);
+		provider.setPasswordEncoder(passwordEncoder);
+		provider.setAuthoritiesMapper(new RoleHierarchyAuthoritiesMapper(roleHierarchy));
+		return provider;
+	}
 
-    @Bean
-    public CustomAuthenticationProvider customAuthenticationProvider(
-            UserDetailsService userDetailsService,
-            PasswordEncoder passwordEncoder
-    ) {
-        return new CustomAuthenticationProvider(userDetailsService, passwordEncoder);
-    }
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+		// 프론트엔드 주소를 정확하게 명시해야 합니다.
+		configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173"));
+		// 필요한 HTTP 메서드를 허용합니다.
+		configuration.setAllowedMethods(
+			Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+		// 모든 헤더를 허용합니다.
+		configuration.setAllowedHeaders(Arrays.asList("*"));
+		// ★★★ 이 설정이 쿠키 전송을 허용하는 핵심입니다.
+		configuration.setAllowCredentials(true);
 
-    @Bean
-    public RoleHierarchy roleHierarchy() {
-        return RoleHierarchyImpl.withDefaultRolePrefix()
-                .role(Role.ADMIN.name())
-                .implies(Role.USER.name())
-                .build();
-    }
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		// 모든 경로("/**")에 위 설정을 적용합니다.
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
+	}
+
+	@Bean
+	public CustomAuthenticationProvider customAuthenticationProvider(
+		UserDetailsService userDetailsService,
+		PasswordEncoder passwordEncoder
+	) {
+		return new CustomAuthenticationProvider(userDetailsService, passwordEncoder);
+	}
+
+	@Bean
+	public RoleHierarchy roleHierarchy() {
+		return RoleHierarchyImpl.withDefaultRolePrefix()
+			.role(Role.ADMIN.name())
+			.implies(Role.USER.name())
+			.build();
+	}
 }

--- a/src/main/java/com/team3/otboo/domain/feed/controller/ViewController.java
+++ b/src/main/java/com/team3/otboo/domain/feed/controller/ViewController.java
@@ -21,7 +21,6 @@ public class ViewController {
 	public ResponseEntity<Long> increase(
 		@PathVariable("feedId") UUID feedId
 	) {
-		log.info("[ViewController.increase()]");
 		Long count = viewService.increase(feedId);
 		return ResponseEntity.ok(count);
 	}

--- a/src/main/java/com/team3/otboo/domain/feed/dto/FeedDto.java
+++ b/src/main/java/com/team3/otboo/domain/feed/dto/FeedDto.java
@@ -22,10 +22,7 @@ public record FeedDto(
 	// 바뀌는 데이터 -> content, likeCount, commentCount, likedByMe, viewCount
 ) {
 
-	public static FeedDto from(
-		FeedQueryModel feedQueryModel,
-		Long likeCount,
-		Long commentCount,
+	public static FeedDto from(FeedQueryModel feedQueryModel, Long likeCount, Long commentCount,
 		Boolean likedByMe) {
 		return new FeedDto(
 			feedQueryModel.getId(),

--- a/src/main/java/com/team3/otboo/domain/feed/dto/FeedDto.java
+++ b/src/main/java/com/team3/otboo/domain/feed/dto/FeedDto.java
@@ -17,13 +17,13 @@ public record FeedDto(
 	String content,
 	Long likeCount,
 	Integer commentCount,
-	Boolean likedByMe
-	// Long viewCount
+	Boolean likedByMe,
+	Long viewCount
 	// 바뀌는 데이터 -> content, likeCount, commentCount, likedByMe, viewCount
 ) {
 
 	public static FeedDto from(FeedQueryModel feedQueryModel, Long likeCount, Long commentCount,
-		Boolean likedByMe) {
+		Boolean likedByMe, Long viewCount) {
 		return new FeedDto(
 			feedQueryModel.getId(),
 			feedQueryModel.getCreatedAt(),
@@ -34,7 +34,8 @@ public record FeedDto(
 			feedQueryModel.getContent(),
 			likeCount,
 			commentCount.intValue(),
-			likedByMe
+			likedByMe,
+			viewCount
 		);
 	}
 }

--- a/src/main/java/com/team3/otboo/domain/feed/mapper/FeedDtoAssembler.java
+++ b/src/main/java/com/team3/otboo/domain/feed/mapper/FeedDtoAssembler.java
@@ -11,6 +11,7 @@ import com.team3.otboo.domain.feed.repository.FeedLikeCountRepository;
 import com.team3.otboo.domain.feed.repository.FeedRepository;
 import com.team3.otboo.domain.feed.repository.LikeRepository;
 import com.team3.otboo.domain.feed.service.OotdService;
+import com.team3.otboo.domain.feed.service.ViewService;
 import com.team3.otboo.domain.user.entity.Profile;
 import com.team3.otboo.domain.user.entity.User;
 import com.team3.otboo.domain.user.repository.UserRepository;
@@ -41,6 +42,7 @@ public class FeedDtoAssembler {
 	private final WeatherRepository weatherRepository;
 	private final LikeRepository likeRepository;
 	private final OotdService ootdService;
+	private final ViewService viewService;
 
 	public FeedDto assemble(UUID feedId, UUID userId) {
 		Feed feed = feedRepository.findById(feedId).orElseThrow(
@@ -82,6 +84,8 @@ public class FeedDtoAssembler {
 		// 내가 좋아요를 눌렀는가 하나 때문에 userId 를 넣어줘야함 .
 		boolean likedByMe = likeRepository.existsByUserIdAndFeedId(userId, feedId);
 
+		Long viewCount = viewService.count(feedId);
+
 		return new FeedDto(
 			feed.getId(),
 			feed.getCreatedAt(),
@@ -92,7 +96,8 @@ public class FeedDtoAssembler {
 			feed.getContent(),
 			likeCount,
 			commentCount,
-			likedByMe
+			likedByMe,
+			viewCount
 		);
 	}
 
@@ -133,6 +138,8 @@ public class FeedDtoAssembler {
 			.map(FeedLikeCount::getLikeCount)
 			.orElse(0L);
 
+		Long viewCount = viewService.count(feedId);
+
 		return new FeedDto(
 			feed.getId(),
 			feed.getCreatedAt(),
@@ -143,7 +150,8 @@ public class FeedDtoAssembler {
 			feed.getContent(),
 			likeCount,
 			commentCount,
-			null
+			null,
+			viewCount
 		);
 	}
 

--- a/src/main/java/com/team3/otboo/domain/feed/repository/FeedLikeCountRepository.java
+++ b/src/main/java/com/team3/otboo/domain/feed/repository/FeedLikeCountRepository.java
@@ -1,6 +1,7 @@
 package com.team3.otboo.domain.feed.repository;
 
 import com.team3.otboo.domain.feed.entity.FeedLikeCount;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -34,4 +35,10 @@ public interface FeedLikeCountRepository extends JpaRepository<FeedLikeCount, UU
 	)
 	@Modifying
 	Long increaseAndGet(@Param("feedId") UUID feedId);
+
+	@Query(
+		value = "SELECT * FROM feed_like_count WHERE feed_id IN (:ids)",
+		nativeQuery = true
+	)
+	List<FeedLikeCount> findAllByIdIn(@Param("ids") List<UUID> ids);
 }

--- a/src/main/java/com/team3/otboo/domain/feed/repository/FeedRepository.java
+++ b/src/main/java/com/team3/otboo/domain/feed/repository/FeedRepository.java
@@ -1,6 +1,7 @@
 package com.team3.otboo.domain.feed.repository;
 
 import com.team3.otboo.domain.feed.entity.Feed;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,4 +19,16 @@ public interface FeedRepository extends JpaRepository<Feed, UUID> {
 	Optional<UUID> findAuthorIdById(
 		@Param("id") UUID feedId
 	);
+
+	/**
+	 * 주어진 UUID 목록에 해당하는 모든 Feed 엔티티를 조회합니다. Native SQL의 IN 절을 사용하여 한번의 쿼리로 모든 데이터를 가져옵니다.
+	 *
+	 * @param ids 조회할 Feed의 UUID 목록
+	 * @return 조회된 Feed 엔티티 목록
+	 */
+	@Query(
+		value = "SELECT * FROM feeds f WHERE f.id IN (:ids)",
+		nativeQuery = true
+	)
+	List<Feed> findAllByIdIn(@Param("ids") List<UUID> ids);
 }

--- a/src/main/java/com/team3/otboo/domain/feed/service/FeedService.java
+++ b/src/main/java/com/team3/otboo/domain/feed/service/FeedService.java
@@ -23,6 +23,8 @@ import com.team3.otboo.domain.feed.service.request.FeedUpdateRequest;
 import com.team3.otboo.domain.feed.service.response.FeedDtoCursorResponse;
 import com.team3.otboo.domain.user.entity.User;
 import com.team3.otboo.domain.user.repository.UserRepository;
+import com.team3.otboo.domain.weather.entity.Weather;
+import com.team3.otboo.domain.weather.repository.WeatherRepository;
 import com.team3.otboo.event.FollowedUserPostedFeedEvent;
 import com.team3.otboo.global.exception.user.UserNotFoundException;
 import jakarta.persistence.EntityNotFoundException;
@@ -56,6 +58,7 @@ public class FeedService {
 	private final FeedViewCountBackUpRepository feedViewCountBackUpRepository;
 
 	private final OutboxEventPublisher outboxEventPublisher;
+	private final WeatherRepository weatherRepository;
 
 	// 알림 기능과 겹치니까 publish 는 한번만 하고, Listener 를 두개 써야함 .
 	// 겹치는거 -> 좋아요 생성 삭제, 댓글 생성 시 알림 가야하고 + 인기 피드 쪽에서 점수 계산까지 해야함 .
@@ -85,6 +88,9 @@ public class FeedService {
 		}
 
 		log.info("[FeedService.create] feed created. feedId: " + feed.getId());
+		Weather weather = weatherRepository.findById(feed.getWeatherId())
+			.orElseThrow(EntityNotFoundException::new);
+
 		outboxEventPublisher.publish(
 			EventType.FEED_CREATED,
 			FeedCreatedEventPayload.builder()
@@ -94,6 +100,8 @@ public class FeedService {
 				.authorId(feed.getAuthorId())
 				.weatherId(feed.getWeatherId())
 				.content(feed.getContent())
+				.skyStatus(weather.getSkyStatus())
+				.precipitationType(weather.getPrecipitation().getType())
 				.build()
 		);
 

--- a/src/main/java/com/team3/otboo/domain/feed/service/LikeService.java
+++ b/src/main/java/com/team3/otboo/domain/feed/service/LikeService.java
@@ -18,12 +18,14 @@ import com.team3.otboo.event.FeedLikedEvent;
 import com.team3.otboo.global.exception.user.UserNotFoundException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class LikeService {
 
 	private final LikeRepository likeRepository;
@@ -69,6 +71,7 @@ public class LikeService {
 				.updatedAt(savedLike.getUpdatedAt())
 				.feedId(savedLike.getFeedId())
 				.userId(savedLike.getUserId())
+				.likeCount(count(feedId))
 				.build()
 		);
 
@@ -92,10 +95,12 @@ public class LikeService {
 						.updatedAt(feedLike.getUpdatedAt())
 						.feedId(feedLike.getFeedId())
 						.userId(feedLike.getUserId())
-						.likeCount(count(feedLike.getFeedId()))
+						.likeCount(count(feedId))
 						.build()
 				);
 			});
+
+		log.info("[LikeService.unlike] count(feedLike.getFeedId(): " + count(feedId));
 	}
 
 	@Transactional

--- a/src/main/java/com/team3/otboo/domain/feed/service/ViewService.java
+++ b/src/main/java/com/team3/otboo/domain/feed/service/ViewService.java
@@ -11,7 +11,6 @@ public class ViewService {
 
 	private final FeedViewCountRepository feedViewCountRepository;
 	private final ViewCountBackUpProcessor viewCountBackUpProcessor;
-	
 	private static final int BACK_UP_BACH_SIZE = 100;
 
 	public Long increase(UUID feedId) {

--- a/src/main/java/com/team3/otboo/domain/feedread/document/FeedDocument.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/document/FeedDocument.java
@@ -1,0 +1,54 @@
+package com.team3.otboo.domain.feedread.document;
+
+import com.team3.otboo.domain.weather.enums.PrecipitationType;
+import com.team3.otboo.domain.weather.enums.SkyStatus;
+import jakarta.persistence.Id;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.InnerField;
+import org.springframework.data.elasticsearch.annotations.MultiField;
+
+@Getter
+@Setter
+@Document(indexName = "feeds")
+public class FeedDocument {
+
+	@Id
+	private UUID id; // feed_id
+
+	@Field(type = FieldType.Date)
+	private Instant createdAt;
+
+	@MultiField(
+		mainField = @Field(type = FieldType.Text, analyzer = "nori"),
+		otherFields = {
+			@InnerField(suffix = "raw", type = FieldType.Keyword, ignoreAbove = 256)
+		}
+	)
+	private String content;
+
+	@Field(type = FieldType.Keyword)
+	private UUID authorId;
+
+	@MultiField(
+		mainField = @Field(type = FieldType.Text, analyzer = "nori"),
+		otherFields = {
+			@InnerField(suffix = "raw", type = FieldType.Keyword, ignoreAbove = 256)
+		}
+	)
+	private String authorName;
+
+	@Field(type = FieldType.Keyword)
+	private SkyStatus skyStatus; // 날씨
+
+	@Field(type = FieldType.Keyword)
+	private PrecipitationType precipitationType; // 강수
+
+	@Field(type = FieldType.Integer)
+	private Integer likeCount;
+}

--- a/src/main/java/com/team3/otboo/domain/feedread/document/MongoFeedDocument.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/document/MongoFeedDocument.java
@@ -1,0 +1,37 @@
+package com.team3.otboo.domain.feedread.document;
+
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+
+@Getter
+@Setter
+//@Document(collection = "feeds_staging") // 데이터를 저장할 MongoDB 컬렉션 이름
+public class MongoFeedDocument {
+
+	@Id // MongoDB의 고유 ID 필드
+	private String id; // String 타입으로 사용하는 것이 일반적
+
+	private Instant createdAt;
+	private String content;
+	private UUID authorId;
+	private String authorName;
+	private String skyStatus;
+	private String precipitationType;
+	private Integer likeCount;
+
+	// elastic search document 를 MongoDB document 로 변환
+	public static MongoFeedDocument from(FeedDocument esDocument) {
+		MongoFeedDocument mongoDoc = new MongoFeedDocument();
+		mongoDoc.setId(esDocument.getId().toString());
+		mongoDoc.setCreatedAt(esDocument.getCreatedAt());
+		mongoDoc.setContent(esDocument.getContent());
+		mongoDoc.setAuthorId(esDocument.getAuthorId());
+		mongoDoc.setSkyStatus(esDocument.getSkyStatus().name());
+		mongoDoc.setPrecipitationType(esDocument.getPrecipitationType().name());
+		mongoDoc.setLikeCount(esDocument.getLikeCount());
+		return mongoDoc;
+	}
+}

--- a/src/main/java/com/team3/otboo/domain/feedread/document/MongoFeedDocument.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/document/MongoFeedDocument.java
@@ -12,7 +12,7 @@ import org.springframework.data.annotation.Id;
 public class MongoFeedDocument {
 
 	@Id // MongoDB의 고유 ID 필드
-	private String id; // String 타입으로 사용하는 것이 일반적
+	private String id;
 
 	private Instant createdAt;
 	private String content;

--- a/src/main/java/com/team3/otboo/domain/feedread/repository/FeedSearchRepository.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/repository/FeedSearchRepository.java
@@ -1,0 +1,9 @@
+package com.team3.otboo.domain.feedread.repository;
+
+import com.team3.otboo.domain.feedread.document.FeedDocument;
+import java.util.UUID;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface FeedSearchRepository extends ElasticsearchRepository<FeedDocument, UUID> {
+
+}

--- a/src/main/java/com/team3/otboo/domain/feedread/repository/MongoFeedDocumentRepository.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/repository/MongoFeedDocumentRepository.java
@@ -1,0 +1,5 @@
+package com.team3.otboo.domain.feedread.repository;
+
+public class MongoFeedDocumentRepository {
+
+}

--- a/src/main/java/com/team3/otboo/domain/feedread/repository/RedisLockManager.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/repository/RedisLockManager.java
@@ -1,0 +1,55 @@
+package com.team3.otboo.domain.feedread.repository;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisLockManager {
+
+	private final StringRedisTemplate redisTemplate;
+
+	/**
+	 * 락을 획득합니다.
+	 *
+	 * @param key     락 키
+	 * @param value   락 소유자를 식별하기 위한 값 (e.g., UUID)
+	 * @param timeout 락 만료 시간
+	 * @return 락 획득 성공 시 true, 실패 시 false
+	 */
+	public boolean acquireLock(String key, String value, Duration timeout) {
+		// SET key value NX EX timeout
+		Boolean success = redisTemplate.opsForValue()
+			.setIfAbsent(key, value, timeout);
+		return success != null && success;
+	}
+
+	/**
+	 * 락이 존재하는지 확인합니다.
+	 *
+	 * @param key 락 키
+	 * @return 락이 존재하면 true, 아니면 false
+	 */
+	public boolean isLockHeld(String key) {
+		return redisTemplate.hasKey(key);
+	}
+
+	/**
+	 * 락을 해제합니다.
+	 *
+	 * @param key   락 키
+	 * @param value 락을 획득할 때 사용했던 값
+	 * @return 락 해제 성공 시 true, 실패 시 false
+	 */
+	public boolean releaseLock(String key, String value) {
+		// 현재 락을 소유한 클라이언트인지 확인
+		String currentValue = redisTemplate.opsForValue().get(key);
+		if (value.equals(currentValue)) {
+			redisTemplate.delete(key);
+			return true;
+		}
+		return false;
+	}
+}

--- a/src/main/java/com/team3/otboo/domain/feedread/service/FeedIndexBatchService.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/service/FeedIndexBatchService.java
@@ -1,0 +1,179 @@
+package com.team3.otboo.domain.feedread.service;
+
+import com.team3.otboo.domain.feed.entity.Feed;
+import com.team3.otboo.domain.feed.entity.FeedLikeCount;
+import com.team3.otboo.domain.feed.repository.FeedLikeCountRepository;
+import com.team3.otboo.domain.feed.repository.FeedRepository;
+import com.team3.otboo.domain.feedread.document.FeedDocument;
+import com.team3.otboo.domain.user.entity.User;
+import com.team3.otboo.domain.user.repository.UserRepository;
+import com.team3.otboo.domain.weather.entity.Weather;
+import com.team3.otboo.domain.weather.repository.WeatherRepository;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.IndexOperations;
+import org.springframework.data.elasticsearch.core.index.AliasAction;
+import org.springframework.data.elasticsearch.core.index.AliasActionParameters;
+import org.springframework.data.elasticsearch.core.index.AliasActions;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.query.IndexQuery;
+import org.springframework.data.elasticsearch.core.query.IndexQueryBuilder;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FeedIndexBatchService {
+
+	private static final int CHUNK_SIZE = 1000; // 한 번에 처리할 데이터 양
+	private static final String FEED_ALIAS = "feeds"; // 애플리케이션이 사용할 고정 별칭
+
+	private final FeedRepository feedRepository;
+	private final WeatherRepository weatherRepository;
+	private final FeedLikeCountRepository feedLikeCountRepository;
+	private final ElasticsearchOperations elasticsearchOperations;
+	private final UserRepository userRepository; // 사용자 정보 조회를 위해 UserRepository 추가
+
+	/**
+	 * 매일 새벽 1시에 실행되는 전체 색인 스케줄러 (Alias를 활용한 무중단 방식).
+	 */
+	@Scheduled(cron = "0 0 1 * * *")
+	@Transactional(readOnly = true)
+	public void runFullIndexingWithAlias() {
+		log.info(">>>>> [BATCH] 무중단 전체 색인 작업을 시작합니다.");
+
+		String newIndexName = FEED_ALIAS + "_" + LocalDateTime.now()
+			.format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
+		IndexCoordinates newIndexCoordinates = IndexCoordinates.of(newIndexName);
+
+		IndexOperations indexOperations = elasticsearchOperations.indexOps(newIndexCoordinates);
+		indexOperations.create();
+		indexOperations.putMapping(FeedDocument.class);
+		log.info(">>>>> [BATCH] 새로운 인덱스 '{}'를 생성했습니다.", newIndexName);
+
+		Pageable pageable = PageRequest.of(0, CHUNK_SIZE);
+		long totalFeedsProcessed = 0;
+
+		while (true) {
+			Page<Feed> feedPage = feedRepository.findAll(pageable);
+			List<Feed> feeds = feedPage.getContent();
+			if (feeds.isEmpty()) {
+				break;
+			}
+
+			processChunk(feeds, newIndexCoordinates);
+
+			totalFeedsProcessed += feeds.size();
+			log.info(">>>>> [BATCH] {}개의 피드를 '{}' 인덱스에 색인 완료. (총 {}개 처리)", feeds.size(),
+				newIndexName, totalFeedsProcessed);
+
+			if (!feedPage.hasNext()) {
+				break;
+			}
+			pageable = feedPage.nextPageable();
+		}
+
+		AliasActions aliasActions = new AliasActions();
+
+		Set<String> oldIndexNames = elasticsearchOperations.indexOps(
+			IndexCoordinates.of(FEED_ALIAS)).getAliasesForIndex("*").keySet();
+		oldIndexNames.forEach(oldIndex -> {
+			AliasActionParameters removeParams = AliasActionParameters.builder()
+				.withAliases(FEED_ALIAS)
+				.withIndices(oldIndex)
+				.build();
+			aliasActions.add(new AliasAction.Remove(removeParams));
+		});
+
+		AliasActionParameters addParams = AliasActionParameters.builder()
+			.withAliases(FEED_ALIAS)
+			.withIndices(newIndexName)
+			.build();
+		aliasActions.add(new AliasAction.Add(addParams));
+
+		if (!aliasActions.getActions().isEmpty()) {
+			elasticsearchOperations.indexOps(newIndexCoordinates).alias(aliasActions);
+		}
+		log.info(">>>>> [BATCH] 별칭 '{}'가 새로운 인덱스 '{}'를 가리키도록 교체했습니다.", FEED_ALIAS, newIndexName);
+
+		oldIndexNames.forEach(oldIndex -> {
+			elasticsearchOperations.indexOps(IndexCoordinates.of(oldIndex)).delete();
+			log.info(">>>>> [BATCH] 옛날 인덱스 '{}'를 삭제했습니다.", oldIndex);
+		});
+
+		log.info(">>>>> [BATCH] 총 {}개의 피드 전체 색인 완료. 작업을 종료합니다.", totalFeedsProcessed);
+	}
+
+	private void processChunk(List<Feed> feeds, IndexCoordinates indexCoordinates) {
+		List<UUID> feedIds = feeds.stream().map(Feed::getId).collect(Collectors.toList());
+		List<UUID> weatherIds = feeds.stream().map(Feed::getWeatherId).collect(Collectors.toList());
+		List<UUID> authorIds = feeds.stream().map(Feed::getAuthorId)
+			.collect(Collectors.toList()); // 작성자 ID 목록 추출
+
+		Map<UUID, Weather> weatherMap = weatherRepository.findAllByIdIn(weatherIds).stream()
+			.collect(Collectors.toMap(Weather::getId, Function.identity()));
+
+		Map<UUID, FeedLikeCount> likeCountMap = feedLikeCountRepository.findAllByIdIn(feedIds)
+			.stream()
+			.collect(Collectors.toMap(FeedLikeCount::getFeedId, Function.identity()));
+
+		// 작성자 ID 목록으로 사용자 정보 조회
+		Map<UUID, User> userMap = userRepository.findAllByIdIn(authorIds).stream()
+			.collect(Collectors.toMap(User::getId, Function.identity()));
+
+		// buildIndexQuery 호출 시 userMap 전달
+		List<IndexQuery> indexQueries = feeds.stream()
+			.map(feed -> buildIndexQuery(feed, weatherMap, likeCountMap, userMap))
+			.collect(Collectors.toList());
+
+		if (!indexQueries.isEmpty()) {
+			elasticsearchOperations.bulkIndex(indexQueries, indexCoordinates);
+		}
+	}
+
+	// buildIndexQuery 메소드에 userMap 파라미터 추가 및 로직 수정
+	private IndexQuery buildIndexQuery(Feed feed, Map<UUID, Weather> weatherMap,
+		Map<UUID, FeedLikeCount> likeCountMap, Map<UUID, User> userMap) {
+		FeedDocument document = new FeedDocument();
+		document.setId(feed.getId());
+		document.setCreatedAt(feed.getCreatedAt());
+		document.setContent(feed.getContent());
+		document.setAuthorId(feed.getAuthorId());
+
+		// userMap에서 사용자 이름을 찾아 Document에 설정
+		User author = userMap.get(feed.getAuthorId());
+		if (author != null) {
+			document.setAuthorName(author.getUsername()); // User 엔티티의 이름 필드(getUsername)를 사용
+		}
+
+		Weather weather = weatherMap.get(feed.getWeatherId());
+		if (weather != null) {
+			document.setSkyStatus(weather.getSkyStatus());
+			document.setPrecipitationType(weather.getPrecipitation().getType());
+		}
+
+		int likeCount = likeCountMap.containsKey(feed.getId())
+			? likeCountMap.get(feed.getId()).getLikeCount().intValue()
+			: 0;
+		document.setLikeCount(likeCount);
+
+		return new IndexQueryBuilder()
+			.withId(document.getId().toString())
+			.withObject(document)
+			.build();
+	}
+}

--- a/src/main/java/com/team3/otboo/domain/feedread/service/event/handler/FeedCreatedEventHandler.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/service/event/handler/FeedCreatedEventHandler.java
@@ -5,9 +5,11 @@ import com.team3.otboo.common.event.EventType;
 import com.team3.otboo.common.event.payload.FeedCreatedEventPayload;
 import com.team3.otboo.domain.feed.dto.FeedDto;
 import com.team3.otboo.domain.feed.mapper.FeedDtoAssembler;
+import com.team3.otboo.domain.feedread.document.FeedDocument;
 import com.team3.otboo.domain.feedread.repository.FeedIdListRepository;
 import com.team3.otboo.domain.feedread.repository.FeedQueryModel;
 import com.team3.otboo.domain.feedread.repository.FeedQueryModelRepository;
+import com.team3.otboo.domain.feedread.repository.FeedSearchRepository;
 import java.time.Duration;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +23,7 @@ public class FeedCreatedEventHandler implements EventHandler<FeedCreatedEventPay
 	private final FeedIdListRepository feedIdListRepository;
 
 	private final FeedDtoAssembler feedDtoAssembler;
+	private final FeedSearchRepository feedSearchRepository;
 
 	@Override
 	public void handle(Event<FeedCreatedEventPayload> event) {
@@ -33,6 +36,17 @@ public class FeedCreatedEventHandler implements EventHandler<FeedCreatedEventPay
 			Duration.ofDays(1)
 		);
 		feedIdListRepository.add(feedId, payload.getCreatedAt(), 1000L); // id list 는 1000개 까지 저장 .
+
+		FeedDocument feedDocument = new FeedDocument();
+		feedDocument.setId(payload.getId());
+		feedDocument.setCreatedAt(payload.getCreatedAt());
+		feedDocument.setContent(payload.getContent());
+		feedDocument.setAuthorId(payload.getAuthorId());
+		feedDocument.setAuthorName(feedDto.author().name());
+		feedDocument.setSkyStatus(payload.getSkyStatus());
+		feedDocument.setPrecipitationType(payload.getPrecipitationType());
+		feedDocument.setLikeCount(0); // 생성시 like count 는 0
+		feedSearchRepository.save(feedDocument);
 	}
 
 	@Override

--- a/src/main/java/com/team3/otboo/domain/feedread/service/event/handler/FeedDeletedEventHandler.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/service/event/handler/FeedDeletedEventHandler.java
@@ -5,6 +5,7 @@ import com.team3.otboo.common.event.EventType;
 import com.team3.otboo.common.event.payload.FeedDeletedEventPayload;
 import com.team3.otboo.domain.feedread.repository.FeedIdListRepository;
 import com.team3.otboo.domain.feedread.repository.FeedQueryModelRepository;
+import com.team3.otboo.domain.feedread.repository.FeedSearchRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -15,11 +16,15 @@ public class FeedDeletedEventHandler implements EventHandler<FeedDeletedEventPay
 	private final FeedQueryModelRepository feedQueryModelRepository;
 	private final FeedIdListRepository feedIdListRepository;
 
+	private final FeedSearchRepository feedSearchRepository;
+
 	@Override
 	public void handle(Event<FeedDeletedEventPayload> event) {
 		FeedDeletedEventPayload payload = event.getPayload();
 		feedQueryModelRepository.delete(payload.getId());
 		feedIdListRepository.delete(payload.getId());
+
+		feedSearchRepository.deleteById(payload.getId());
 	}
 
 	@Override

--- a/src/main/java/com/team3/otboo/domain/feedread/service/event/handler/FeedLikedEventHandler.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/service/event/handler/FeedLikedEventHandler.java
@@ -34,7 +34,6 @@ public class FeedLikedEventHandler implements EventHandler<FeedLikedEventPayload
 				Long likeCount = payload.getLikeCount();
 
 				Map<String, Object> patch = Map.of("likeCount", likeCount);
-				log.info("[FeedLikedEventHandler.handle] likeCount: {}", likeCount);
 				UpdateQuery updateQuery = UpdateQuery.builder(feedQueryModel.getId().toString())
 					.withDocument(Document.from(patch))
 					.build();

--- a/src/main/java/com/team3/otboo/domain/feedread/service/event/handler/FeedLikedEventHandler.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/service/event/handler/FeedLikedEventHandler.java
@@ -4,14 +4,23 @@ import com.team3.otboo.common.event.Event;
 import com.team3.otboo.common.event.EventType;
 import com.team3.otboo.common.event.payload.FeedLikedEventPayload;
 import com.team3.otboo.domain.feedread.repository.FeedQueryModelRepository;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.document.Document;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.query.UpdateQuery;
 import org.springframework.stereotype.Component;
 
 @Component("feedReadFeedLikedEventHandler")
 @RequiredArgsConstructor
+@Slf4j
 public class FeedLikedEventHandler implements EventHandler<FeedLikedEventPayload> {
 
 	private final FeedQueryModelRepository feedQueryModelRepository;
+
+	private final ElasticsearchOperations elasticsearchOperations;
 
 	@Override
 	public void handle(Event<FeedLikedEventPayload> event) {
@@ -21,6 +30,16 @@ public class FeedLikedEventHandler implements EventHandler<FeedLikedEventPayload
 			.ifPresent(feedQueryModel -> {
 				feedQueryModel.updateBy(payload);
 				feedQueryModelRepository.update(feedQueryModel);
+
+				Long likeCount = payload.getLikeCount();
+
+				Map<String, Object> patch = Map.of("likeCount", likeCount);
+				log.info("[FeedLikedEventHandler.handle] likeCount: {}", likeCount);
+				UpdateQuery updateQuery = UpdateQuery.builder(feedQueryModel.getId().toString())
+					.withDocument(Document.from(patch))
+					.build();
+
+				elasticsearchOperations.update(updateQuery, IndexCoordinates.of("feeds"));
 			});
 	}
 

--- a/src/main/java/com/team3/otboo/domain/feedread/service/event/handler/FeedUnlikedEventHandler.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/service/event/handler/FeedUnlikedEventHandler.java
@@ -4,14 +4,23 @@ import com.team3.otboo.common.event.Event;
 import com.team3.otboo.common.event.EventType;
 import com.team3.otboo.common.event.payload.FeedUnlikedEventPayload;
 import com.team3.otboo.domain.feedread.repository.FeedQueryModelRepository;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.document.Document;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.query.UpdateQuery;
 import org.springframework.stereotype.Component;
 
 @Component("feedReadFeedUnlikedEventHandler")
 @RequiredArgsConstructor
+@Slf4j
 public class FeedUnlikedEventHandler implements EventHandler<FeedUnlikedEventPayload> {
 
 	private final FeedQueryModelRepository feedQueryModelRepository;
+
+	private final ElasticsearchOperations elasticsearchOperations;
 
 	@Override
 	public void handle(Event<FeedUnlikedEventPayload> event) {
@@ -20,6 +29,16 @@ public class FeedUnlikedEventHandler implements EventHandler<FeedUnlikedEventPay
 			.ifPresent(feedQueryModel -> {
 				feedQueryModel.updateBy(payload);
 				feedQueryModelRepository.update(feedQueryModel);
+
+				Long likeCount = payload.getLikeCount();
+				log.info("[FeedUnlikedEventHandler.handle] likeCount: {}", likeCount);
+
+				Map<String, Object> patch = Map.of("likeCount", likeCount);
+				UpdateQuery updateQuery = UpdateQuery.builder(feedQueryModel.getId().toString())
+					.withDocument(Document.from(patch))
+					.build();
+
+				elasticsearchOperations.update(updateQuery, IndexCoordinates.of("feeds"));
 			});
 	}
 

--- a/src/main/java/com/team3/otboo/domain/feedread/service/event/handler/FeedUpdatedEventHandler.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/service/event/handler/FeedUpdatedEventHandler.java
@@ -3,8 +3,15 @@ package com.team3.otboo.domain.feedread.service.event.handler;
 import com.team3.otboo.common.event.Event;
 import com.team3.otboo.common.event.EventType;
 import com.team3.otboo.common.event.payload.FeedUpdatedEventPayload;
+import com.team3.otboo.domain.feedread.document.FeedDocument;
 import com.team3.otboo.domain.feedread.repository.FeedQueryModelRepository;
+import com.team3.otboo.domain.feedread.repository.FeedSearchRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.query.UpdateQuery;
 import org.springframework.stereotype.Component;
 
 @Component("feedReadFeedUpdatedEventHandler")
@@ -13,6 +20,9 @@ public class FeedUpdatedEventHandler implements EventHandler<FeedUpdatedEventPay
 
 	private final FeedQueryModelRepository feedQueryModelRepository;
 
+	private final FeedSearchRepository feedSearchRepository;
+	private final ElasticsearchOperations elasticsearchOperations;
+
 	@Override
 	public void handle(Event<FeedUpdatedEventPayload> event) {
 		FeedUpdatedEventPayload payload = event.getPayload();
@@ -20,7 +30,20 @@ public class FeedUpdatedEventHandler implements EventHandler<FeedUpdatedEventPay
 			.ifPresent(feedQueryModel -> {
 				feedQueryModel.updateBy(payload);
 				feedQueryModelRepository.update(feedQueryModel);
+
 			});
+
+		FeedDocument feedDocument = feedSearchRepository.findById(payload.getId()).orElseThrow(() ->
+			new EntityNotFoundException(
+				"[FeedUpdatedEventHandler.handle] feed document not found. feed id: "
+					+ payload.getId())
+		);
+
+		Map<String, Object> patch = Map.of("content", payload.getContent());
+		UpdateQuery uq = UpdateQuery.builder(payload.getId().toString())
+			.withDocument(org.springframework.data.elasticsearch.core.document.Document.from(patch))
+			.build();
+		elasticsearchOperations.update(uq, IndexCoordinates.of("feeds"));
 	}
 
 	@Override

--- a/src/main/java/com/team3/otboo/domain/feedread/service/response/FeedReadResponse.java
+++ b/src/main/java/com/team3/otboo/domain/feedread/service/response/FeedReadResponse.java
@@ -24,9 +24,12 @@ public class FeedReadResponse {
 	private Integer commentCount;
 	private Boolean likedByMe;
 
+	private Long viewCount;
+
 //	private Long viewCount;
 
-	public static FeedReadResponse from(FeedQueryModel feedQueryModel, Boolean likedByMe) {
+	public static FeedReadResponse from(FeedQueryModel feedQueryModel, Boolean likedByMe,
+		Long viewCount) {
 		FeedReadResponse response = new FeedReadResponse();
 		response.id = feedQueryModel.getId();
 		response.createdAt = feedQueryModel.getCreatedAt();
@@ -38,7 +41,7 @@ public class FeedReadResponse {
 		response.likeCount = feedQueryModel.getLikeCount();
 		response.commentCount = feedQueryModel.getCommentCount();
 		response.likedByMe = likedByMe;
-//		response.viewCount = viewCount;
+		response.viewCount = viewCount;
 		return response;
 	}
 

--- a/src/main/java/com/team3/otboo/domain/hot/service/HotFeedScoreCalculator.java
+++ b/src/main/java/com/team3/otboo/domain/hot/service/HotFeedScoreCalculator.java
@@ -4,6 +4,7 @@ import com.team3.otboo.domain.feed.entity.FeedCommentCount;
 import com.team3.otboo.domain.feed.entity.FeedLikeCount;
 import com.team3.otboo.domain.feed.repository.FeedCommentCountRepository;
 import com.team3.otboo.domain.feed.repository.FeedLikeCountRepository;
+import com.team3.otboo.domain.feed.repository.FeedViewCountRepository;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -14,12 +15,11 @@ public class HotFeedScoreCalculator {
 
 	private final FeedLikeCountRepository feedLikeCountRepository;
 	private final FeedCommentCountRepository feedCommentCountRepository;
+	private final FeedViewCountRepository feedViewCountRepository;
 
 	// 가중치 like, comment 3:1
-	private static final long FEED_LIKE_COUNT_WEIGHT = 3;
-	private static final long FEED_COMMENT_COUNT_WEIGHT = 1;
-
-	// TODO: view service 만든 후 구현 .
+	private static final long FEED_LIKE_COUNT_WEIGHT = 6;
+	private static final long FEED_COMMENT_COUNT_WEIGHT = 3;
 	private static final long FEED_VIEW_COUNT_WEIGHT = 1;
 
 	public long calculate(UUID feedId) {
@@ -30,7 +30,10 @@ public class HotFeedScoreCalculator {
 			.map(FeedCommentCount::getCommentCount)
 			.orElse(0L);
 
+		Long viewCount = feedViewCountRepository.read(feedId);
+
 		return likeCount * FEED_LIKE_COUNT_WEIGHT
-			+ commentCount * FEED_COMMENT_COUNT_WEIGHT;
+			+ commentCount * FEED_COMMENT_COUNT_WEIGHT
+			+ viewCount * FEED_VIEW_COUNT_WEIGHT;
 	}
 }

--- a/src/main/java/com/team3/otboo/domain/hot/service/HotFeedScoreCalculator.java
+++ b/src/main/java/com/team3/otboo/domain/hot/service/HotFeedScoreCalculator.java
@@ -7,10 +7,12 @@ import com.team3.otboo.domain.feed.repository.FeedLikeCountRepository;
 import com.team3.otboo.domain.feed.repository.FeedViewCountRepository;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class HotFeedScoreCalculator {
 
 	private final FeedLikeCountRepository feedLikeCountRepository;
@@ -32,6 +34,11 @@ public class HotFeedScoreCalculator {
 
 		Long viewCount = feedViewCountRepository.read(feedId);
 
+		log.info("[HotFeedScoreCalculator] score: {}",
+			likeCount * FEED_LIKE_COUNT_WEIGHT
+				+ commentCount * FEED_COMMENT_COUNT_WEIGHT
+				+ viewCount * FEED_VIEW_COUNT_WEIGHT);
+		
 		return likeCount * FEED_LIKE_COUNT_WEIGHT
 			+ commentCount * FEED_COMMENT_COUNT_WEIGHT
 			+ viewCount * FEED_VIEW_COUNT_WEIGHT;

--- a/src/main/java/com/team3/otboo/domain/hot/service/HotFeedScoreUpdater.java
+++ b/src/main/java/com/team3/otboo/domain/hot/service/HotFeedScoreUpdater.java
@@ -38,7 +38,7 @@ public class HotFeedScoreUpdater {
 
 		eventHandler.handle(event);
 
-		// 댓글 생성, 좋아요 생성 삭제 때마다 score 를 갱신해줘야함 .. -> 이런거 부하가 심하지 않나 .
+		// 댓글 생성, 좋아요 생성 삭제, 조회수 증가 때마다 score 를 갱신해줘야함 .. -> 이런거 부하가 심하지 않나 .
 		long score = hotFeedScoreCalculator.calculate(feedId);
 
 		log.info("[HotFeedScoreUpdater.update] feedId: " + feedId + ", score: " + score);

--- a/src/main/java/com/team3/otboo/domain/hot/service/event/handler/FeedViewEventHandler.java
+++ b/src/main/java/com/team3/otboo/domain/hot/service/event/handler/FeedViewEventHandler.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 
-@Component("hotFeedUnlikedEventHandler")
+@Component("hotFeedViewedEventHandler")
 @RequiredArgsConstructor
 public class FeedViewEventHandler implements EventHandler<FeedViewedEventPayload> {
 

--- a/src/main/java/com/team3/otboo/domain/hot/service/event/handler/FeedViewEventHandler.java
+++ b/src/main/java/com/team3/otboo/domain/hot/service/event/handler/FeedViewEventHandler.java
@@ -1,0 +1,28 @@
+package com.team3.otboo.domain.hot.service.event.handler;
+
+import com.team3.otboo.common.event.Event;
+import com.team3.otboo.common.event.EventType;
+import com.team3.otboo.common.event.payload.FeedViewedEventPayload;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+
+@Component("hotFeedUnlikedEventHandler")
+@RequiredArgsConstructor
+public class FeedViewEventHandler implements EventHandler<FeedViewedEventPayload> {
+
+	@Override
+	public void handle(Event<FeedViewedEventPayload> event) {
+	}
+
+	@Override
+	public boolean supports(Event<FeedViewedEventPayload> event) {
+		return event.getType() == EventType.FEED_VIEWED;
+	}
+
+	@Override
+	public UUID findFeedId(Event<FeedViewedEventPayload> event) {
+		return event.getPayload().getFeedId();
+	}
+}

--- a/src/main/java/com/team3/otboo/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/team3/otboo/domain/notification/service/NotificationService.java
@@ -4,94 +4,107 @@ import com.team3.otboo.domain.notification.dto.NotificationDto;
 import com.team3.otboo.domain.notification.dto.NotificationDtoCursorResponse;
 import com.team3.otboo.domain.notification.dto.NotificationSearchCondition;
 import com.team3.otboo.domain.notification.entity.Notification;
-import com.team3.otboo.domain.notification.enums.SortDirection;
 import com.team3.otboo.domain.notification.mapper.NotificationMapper;
 import com.team3.otboo.domain.notification.repository.NotificationRepository;
 import com.team3.otboo.domain.notification.service.strategy.NotificationStrategy;
 import com.team3.otboo.domain.user.entity.User;
 import com.team3.otboo.domain.user.repository.UserRepository;
-import com.team3.otboo.global.exception.user.UserNotFoundException;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.event.EventListener;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@RequiredArgsConstructor
 public class NotificationService {
 
-  private final NotificationRepository notificationRepository;
-  private final RedisTemplate<String, Object> redisTemplate;
-  private final NotificationMapper notificationMapper;
-  private final List<NotificationStrategy<?>> strategies;
-  private final UserRepository userRepository;
+	private final NotificationRepository notificationRepository;
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final NotificationMapper notificationMapper;
+	private final List<NotificationStrategy<?>> strategies;
+	private final UserRepository userRepository;
 
-  private static final Set<String> ALLOWED_SORT_PROPERTIES = Set.of("createdAt", "title");
+	private static final Set<String> ALLOWED_SORT_PROPERTIES = Set.of("createdAt", "title");
 
+	// 👇 2. 생성자를 직접 작성하고, 파라미터에 @Qualifier를 붙여줍니다.
+	public NotificationService(
+		NotificationRepository notificationRepository,
+		@Qualifier("chatPubSub") RedisTemplate<String, Object> redisTemplate,
+		NotificationMapper notificationMapper,
+		List<NotificationStrategy<?>> strategies,
+		UserRepository userRepository
+	) {
+		this.notificationRepository = notificationRepository;
+		this.redisTemplate = redisTemplate;
+		this.notificationMapper = notificationMapper;
+		this.strategies = strategies;
+		this.userRepository = userRepository;
+	}
 
-  @EventListener
-  @Transactional
-  public void handleEvent(Object event) {
-    strategies.stream()
-        .filter(strategy -> strategy.supports(event))
-        .findFirst()
-        .ifPresent(strategy -> processNotification(strategy, event));
-  }
+	@EventListener
+	@Transactional
+	public void handleEvent(Object event) {
+		strategies.stream()
+			.filter(strategy -> strategy.supports(event))
+			.findFirst()
+			.ifPresent(strategy -> processNotification(strategy, event));
+	}
 
-  @SuppressWarnings("unchecked")
-  private <E> void processNotification(NotificationStrategy<E> strategy, Object event) {
-    List<Notification> notifications = strategy.createNotification((E) event);
+	@SuppressWarnings("unchecked")
+	private <E> void processNotification(NotificationStrategy<E> strategy, Object event) {
+		List<Notification> notifications = strategy.createNotification((E) event);
 
-    for (Notification notification : notifications) {
-      notificationRepository.save(notification);
-      NotificationDto dto = notificationMapper.toDto(notification);
-      redisTemplate.convertAndSend("notification-channel", dto);
-    }
-  }
+		for (Notification notification : notifications) {
+			notificationRepository.save(notification);
+			NotificationDto dto = notificationMapper.toDto(notification);
+			redisTemplate.convertAndSend("notification-channel", dto);
+		}
+	}
 
-  @Transactional(readOnly = true)
-  public NotificationDtoCursorResponse findNotificationsByUserId(UUID userId, NotificationSearchCondition condition) {
-    if (!ALLOWED_SORT_PROPERTIES.contains(condition.sortBy())) {
-      throw new IllegalArgumentException("Invalid sort property: " + condition.sortBy());
-    }
+	@Transactional(readOnly = true)
+	public NotificationDtoCursorResponse findNotificationsByUserId(UUID userId,
+		NotificationSearchCondition condition) {
+		if (!ALLOWED_SORT_PROPERTIES.contains(condition.sortBy())) {
+			throw new IllegalArgumentException("Invalid sort property: " + condition.sortBy());
+		}
 
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new RuntimeException("User not found")); // 예외처리 필요
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new RuntimeException("User not found")); // 예외처리 필요
 
-    List<Notification> notifications = notificationRepository.findByReceiverWithCursor(
-        user,
-        condition
-    );
+		List<Notification> notifications = notificationRepository.findByReceiverWithCursor(
+			user,
+			condition
+		);
 
-    boolean hasNext = notifications.size() > condition.limit();
-    List<Notification> currentPage = hasNext ? notifications.subList(0, condition.limit()) : notifications;
+		boolean hasNext = notifications.size() > condition.limit();
+		List<Notification> currentPage =
+			hasNext ? notifications.subList(0, condition.limit()) : notifications;
 
-    List<NotificationDto> dtoList = notificationMapper.toDtoList(currentPage);
+		List<NotificationDto> dtoList = notificationMapper.toDtoList(currentPage);
 
-    String nextCursorValue = null;
-    UUID nextIdAfterValue = null;
-    if (hasNext) {
-      Notification lastNotification = currentPage.getLast();
-      if ("title".equals(condition.sortBy())) {
-        nextCursorValue = lastNotification.getTitle();
-      } else {
-        nextCursorValue = lastNotification.getCreatedAt().toString();
-      }
-      nextIdAfterValue = lastNotification.getId();
-    }
+		String nextCursorValue = null;
+		UUID nextIdAfterValue = null;
+		if (hasNext) {
+			Notification lastNotification = currentPage.getLast();
+			if ("title".equals(condition.sortBy())) {
+				nextCursorValue = lastNotification.getTitle();
+			} else {
+				nextCursorValue = lastNotification.getCreatedAt().toString();
+			}
+			nextIdAfterValue = lastNotification.getId();
+		}
 
-    return new NotificationDtoCursorResponse(
-        dtoList,
-        nextCursorValue,
-        nextIdAfterValue,
-        hasNext,
-        notificationRepository.countByReceiver(user),
-        condition.sortBy(),
-        condition.sortDirection()
-    );
-  }
+		return new NotificationDtoCursorResponse(
+			dtoList,
+			nextCursorValue,
+			nextIdAfterValue,
+			hasNext,
+			notificationRepository.countByReceiver(user),
+			condition.sortBy(),
+			condition.sortDirection()
+		);
+	}
 }

--- a/src/main/java/com/team3/otboo/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/team3/otboo/domain/user/repository/UserRepository.java
@@ -1,9 +1,12 @@
 package com.team3.otboo.domain.user.repository;
 
 import com.team3.otboo.domain.user.entity.User;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -16,4 +19,16 @@ public interface UserRepository extends JpaRepository<User, UUID>, UserRepositor
 	Optional<User> findByUsername(String username);
 
 	Optional<User> findByEmail(String email);
+
+	/**
+	 * 주어진 ID 목록에 해당하는 모든 사용자를 조회합니다.
+	 *
+	 * @param ids 조회할 사용자 ID 목록
+	 * @return 조회된 사용자 엔티티 목록
+	 */
+	@Query(
+		value = "SELECT * FROM users WHERE id IN (:ids)",
+		nativeQuery = true)
+	List<User> findAllByIdIn(@Param("ids") List<UUID> ids);
+
 }

--- a/src/main/java/com/team3/otboo/domain/weather/repository/WeatherRepository.java
+++ b/src/main/java/com/team3/otboo/domain/weather/repository/WeatherRepository.java
@@ -1,7 +1,6 @@
 package com.team3.otboo.domain.weather.repository;
 
 import com.team3.otboo.domain.weather.entity.Weather;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -14,36 +13,44 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface WeatherRepository extends JpaRepository<Weather, UUID> {
-    @Query("""
-      SELECT w 
-      FROM Weather w 
-      WHERE w.location.x  = :x
-        AND w.location.y = :y
-        AND FUNCTION('date', w.forecastAt) = :forecastDate
-      ORDER BY w.forecastAt DESC
-    """)
-    Optional<Weather> findxByyAndForecastDate(
-            @Param("x")     double x,
-            @Param("y")    double y,
-            @Param("forecastDate") LocalDate forecastDate
-    );
 
-    Optional<Weather> findByLocation_XAndLocation_YAndForecastAt(Integer x, Integer y, LocalDateTime forecastAt);
+	@Query("""
+		  SELECT w 
+		  FROM Weather w 
+		  WHERE w.location.x  = :x
+		    AND w.location.y = :y
+		    AND FUNCTION('date', w.forecastAt) = :forecastDate
+		  ORDER BY w.forecastAt DESC
+		""")
+	Optional<Weather> findxByyAndForecastDate(
+		@Param("x") double x,
+		@Param("y") double y,
+		@Param("forecastDate") LocalDate forecastDate
+	);
 
-    @Query("""
-    SELECT w
-    FROM Weather w
-    WHERE w.location.x = :x
-      AND w.location.y = :y
-      AND w.forecastedAt = :forecastedAt
-      AND w.forecastAt >= :fromForecastAt
-      AND w.forecastAt < :toForecastAt
-    """)
-    List<Weather> findWeathersWithForecastedAt(
-            @Param("x") Integer x,
-            @Param("y") Integer y,
-            @Param("forecastedAt") LocalDateTime forecastedAt,
-            @Param("fromForecastAt") LocalDateTime fromForecastAt,
-            @Param("toForecastAt") LocalDateTime toForecastAt
-    );
+	Optional<Weather> findByLocation_XAndLocation_YAndForecastAt(Integer x, Integer y,
+		LocalDateTime forecastAt);
+
+	@Query("""
+		SELECT w
+		FROM Weather w
+		WHERE w.location.x = :x
+		  AND w.location.y = :y
+		  AND w.forecastedAt = :forecastedAt
+		  AND w.forecastAt >= :fromForecastAt
+		  AND w.forecastAt < :toForecastAt
+		""")
+	List<Weather> findWeathersWithForecastedAt(
+		@Param("x") Integer x,
+		@Param("y") Integer y,
+		@Param("forecastedAt") LocalDateTime forecastedAt,
+		@Param("fromForecastAt") LocalDateTime fromForecastAt,
+		@Param("toForecastAt") LocalDateTime toForecastAt
+	);
+
+	@Query(
+		value = "SELECT * FROM weather w WHERE w.id IN (:ids)",
+		nativeQuery = true
+	)
+	List<Weather> findAllByIdIn(@Param("ids") List<UUID> ids);
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,3 +10,5 @@ logging:
     org.hibernate.SQL: info
     org.hibernate.orm.jdbc.bind: info
     org.apache.kafka: WARN
+    org.springframework.data.elasticsearch.client: TRACE
+    org.elasticsearch.client: TRACE

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -77,7 +77,7 @@ spring:
 
   elasticsearch:
     uris:
-      - http://15.164.170.61:9200
+      ${ELASTICSEARCH_URIS:localhost:9200}
 
 server:
   port: 8080

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -75,6 +75,10 @@ spring:
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       enable-auto-commit: false
 
+  elasticsearch:
+    uris:
+      - http://15.164.170.61:9200
+
 server:
   port: 8080
 


### PR DESCRIPTION
## 개요
### 조회수 서비스(View Service) 설계

조회수 → 댓글 수, 좋아요 수 처럼 다른 데이터의 개수로 파생되는 것이 아니므로 사용자는 누가 조회했는지 확인할 수 없고, 조회수만 볼 수 있습니다. 따라서 조회수는 데이터의 일관성이 비교적 중요하지 않습니다.

(좋아요 수, 댓글 수는 직접 목록을 볼 수 있음)

또한 트래픽이 아주 많을 수 있어, 빠르게 쓰기와 조회가 이루어져야한다는 특징이 있습니다.

그래서 조회수의 데이터베이스를 인메모리 데이터베이스인 Redis 로 채택하여 빠르게 읽고 쓸 수 있도록 하고, 

완전히 유실되어서는 안되므로 Postgres 에 개수 단위 (100개) 로 백업했습니다. (ViewBackupProcessor)

**조회수 어뷰징 방지 정책 with Redis**

1. 조회수 증가 요청이 오면, Redis에 TTL을 설정한 후 데이터를 저장
2. feedId + userId 를 조합하여 키를 만들고 해당 키에 이미 저장된 데이터가 있으면 조회수를 증가x