### PR TITLE
Refactor: 캐시 저장 시간 변경 및 기본 StringRedisTemplate 변경

### DIFF
--- a/src/main/java/com/team3/otboo/config/RedisCacheConnectionConfig.java
+++ b/src/main/java/com/team3/otboo/config/RedisCacheConnectionConfig.java
@@ -64,7 +64,7 @@ public class RedisCacheConnectionConfig {
                 // 캐시별 TTL
                 .withCacheConfiguration("clothingList",  defaults.entryTtl(Duration.ofSeconds(60)))
                 .withCacheConfiguration("attrSnapshot",  defaults.entryTtl(Duration.ofHours(6)))
-                .withCacheConfiguration("attrDefsPage", defaults.entryTtl(Duration.ofSeconds(60)))
+                .withCacheConfiguration("attrDefsPage", defaults.entryTtl(Duration.ofSeconds(300)))
                 .build();
     }
 }

--- a/src/main/java/com/team3/otboo/config/RedisTemplateConfig.java
+++ b/src/main/java/com/team3/otboo/config/RedisTemplateConfig.java
@@ -3,20 +3,18 @@ package com.team3.otboo.config;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
 @Configuration
 public class RedisTemplateConfig {
 
-    /** 기본 제공(Primary): 캐시(DB=1, SSL 반영된 @Qualifier("cache") 커넥션 사용) */
-    @Bean(name = "cacheStringRedisTemplate")
-    @Primary
-    public StringRedisTemplate cacheStringRedisTemplate(
-            @Qualifier("cache") RedisConnectionFactory cf) {
-        return new StringRedisTemplate(cf);
-    }
+//    /**  캐시(DB=1, SSL 반영된 @Qualifier("cache") 커넥션 사용) */
+//    @Bean(name = "cacheStringRedisTemplate")
+//    public StringRedisTemplate cacheStringRedisTemplate(
+//            @Qualifier("cache") RedisConnectionFactory cf) {
+//        return new StringRedisTemplate(cf);
+//    }
 
     /** 필요 시 pub/sub 쪽에서도 StringRedisTemplate이 요구되면 사용 */
     @Bean(name = "chatStringRedisTemplate")


### PR DESCRIPTION
### 속성 값의 저장 시간은 60초 -> 300초로 변경
- 속성 값의 경우 관리자가 변경하기 때문에, 자주 변경되지 않을 것이라 판단하여 캐시 시간을 늘렸습니다.

### 기본 StringRedisTemplate 롤백
- 새로운 RedisConnectionFactory를 만들면서, 팩토리가 2개가 존재하게 되었고.
StringRedisTemplate이 자동설정되지 않아 이를 구분하기 위한 RedisTemplateConfig 파일을 제작했었습니다.
재차 확인해보니 제 로직에서는 StringRedisTemplate을 사용하지 않고 있어서 기존에 사용되던 StringRedisTemplate이 사용될 수 있도록 변경하였습니다.