### PR TITLE
Refactor : LLM이 추측하지 못한 값도 사용자가 선택할 수 있도록 변경

### DIFF
--- a/src/main/java/com/team3/otboo/domain/clothing/mapper/ClothingDtoMerger.java
+++ b/src/main/java/com/team3/otboo/domain/clothing/mapper/ClothingDtoMerger.java
@@ -5,6 +5,7 @@ import com.team3.otboo.domain.clothing.dto.ClothesDto;
 import com.team3.otboo.domain.clothing.dto.response.HtmlExtractionResult;
 import com.team3.otboo.domain.clothing.dto.response.VisionAnalysisResult;
 import java.util.List;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -12,20 +13,27 @@ public class ClothingDtoMerger {
 
     public ClothesDto merge(
             HtmlExtractionResult html,
-            VisionAnalysisResult vision,
+            @Nullable VisionAnalysisResult vision,
             List<ClothesAttributeWithDefDto> normalizedAttributes
     ) {
-        String name = (vision.name() != null && !vision.name().isBlank())
-                ? vision.name()
-                : html.title();
+        String name = (vision != null && notBlank(vision.name()))
+                ? vision.name().trim()
+                : safe(html.title());
+
+        // type은 vision이 주지 않으면 null 유지(프론트에서 기존 선택값/placeholder)
+        String type = (vision != null && notBlank(vision.type()))
+                ? vision.type().trim()
+                : null;
 
         return new ClothesDto(
                 null,                  // id는 저장 시 할당
                 null,
                 name,
-                html.imageUrl(),
-                vision.type(),
+                safe(html.imageUrl()),
+                type,
                 normalizedAttributes    // 정규화된 속성 사용
         );
     }
+    private static boolean notBlank(String s) { return s != null && !s.trim().isEmpty(); }
+    private static String safe(String s) { return s == null ? "" : s; }
 }


### PR DESCRIPTION
[변경 전 - 추측에 성공한 이름, 상의를 제외한 속성 값이 사라짐]
<img width="381" height="451" alt="image" src="https://github.com/user-attachments/assets/60c85cd4-1452-434d-a703-6bc44a1fa6ea" />

[변경 후 - 추측에 성공하지 못한 색상, 소재에 대한 드롭다운이 여전히 남아있음]
<img width="422" height="718" alt="image" src="https://github.com/user-attachments/assets/27ac4bcb-26e7-49e7-a842-f7901287d8f7" />


기존에는 LLM이 추측하지 못한 속성에 대한 선택이 불가능하였습니다.
반환값을 null로 재차 세팅해서 해당 오류를 수정하였습니다.